### PR TITLE
feat: Avoid spiky latency with streaming block heights preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.5.0...HEAD)
 
+- Avoid spiky latency with streaming block heights preload
 
 ## [0.5.0](https://github.com/near/near-lake-framework/compare/v0.4.1...v0.5.0) - 2022-06-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
 near-indexer-primitives = ">=0.12.0,<0.15.0"
+async-stream = "0.3.3"


### PR DESCRIPTION
It is extremely hard to make benchmarks over S3. My results were quite unstable throughout the day (I used two servers: one in the US and another in Europe), and at some point, these changes showed significantly worse results, but now they show superior and stable results beating the best results I saw today.

The results from the US server seemed to be completely useless from the benchmark point of view, but then it seems the variance is quite high even when using a server in Europe (I run all the tests for 1-2 minutes several times in a row):

* 0.5.0 version was reaching 150-200 bps in the morning and now
* this PR hit the limit of 90-100 bps in the morning, but now it reaches 210-220 bps
* near-lake-framework-js reaches 34-42 bps
* near-lake-framework-py reaches 6-14 bps

Given that our Lake S3 buckets are in Europe, I find much better and stable results when I run the benchmark from a server in Europe:

* 0.5.0 version reaches 210-220 bps
* this PR reaches 300 bps (still dips to 100 bps sometimes)
* near-lake-framework-js gives 14-40 bps
* near-lake-framework-py gives 14-23 bps

Interestingly, I hit the CPU in this benchmark, so I think I will need to try to use a beefier server for the benchmarks going forward.