### PR TITLE
fix: Fixed the issue of messages being constantly delayed by 100 blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.5.1...HEAD)
 
+- Fixed the bug that caused a lag by 100 blocks that was introduced in 0.5.1
+
 ## [0.5.1](https://github.com/near/near-lake-framework/compare/v0.5.0...v0.5.1)
 
 - Avoid spiky latency with streaming block heights preload


### PR DESCRIPTION
I have tested it on the same benchmark as #44, and the results are quite unstable, but overall it is quite fast anyway and I don't see spikes, which is good.

I believe we should release a new patch release as soon as this PR lands.