### PR TITLE
chore: Release 0.6.0, upgrade near-indexer-primitives dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.5.1...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.0...HEAD)
+
+## [0.6.0](https://github.com/near/near-lake-framework/compare/v0.5.2...0.6.0)
+
+- Upgrade underlying dependency `near-indexer-primitives` to versions between 0.15 and 0.16
+
+### Breaking change
+
+`near-indexer-primitives` reflects some breaking changes in the data types. Some of the fields that were previously
+a base64-encoded String that now became raw `Vec<u8>`:
+
+- `views::ActionView::FunctionCall.args`
+- `views::QueryResponseKind::ViewState`
+- `views::ExecutionStatusView::SuccessValue`
+
+**Refer to this [`nearcore` commit](https://github.com/near/nearcore/commit/8e9be9fff4d520993c81b0e3738c0f223a9538c0) to find all the changes of this kind.**
 
 ## [0.5.2](https://github.com/near/near-lake-framework/compare/v0.5.1...0.5.2)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.58.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.5.2"
+version = "0.6.0"
 
 [dependencies]
 anyhow = "1.0.51"
@@ -27,5 +27,5 @@ tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
-near-indexer-primitives = ">=0.12.0,<0.15.0"
+near-indexer-primitives = ">=0.15.0,<0.16.0"
 async-stream = "0.3.3"


### PR DESCRIPTION
This PR upgrades NEAR Lake Framework to 0.6.0 version.

This upgrade introduces a breaking change since this version underlying `near-indexer-primitives` of versions between 0.15 and 0.16 is allowed.

`near-indexer-primitives` reflects some breaking changes in the data types. Some of the fields that were previously
a base64-encoded String that now became raw `Vec<u8>`:

- `views::ActionView::FunctionCall.args`
- `views::QueryResponseKind::ViewState`
- `views::ExecutionStatusView::SuccessValue`

**Refer to this [`nearcore` commit](https://github.com/near/nearcore/commit/8e9be9fff4d520993c81b0e3738c0f223a9538c0) to find all the changes of this kind.**

Resolves #48 