### PR TITLE
refactor: Internal renaming, more logs, proper error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.0...HEAD)
 
+- Fix of possible silent stops of the streamer (firing logs and returning errors where necessary)
+- Fix the issue the streamer was always 1 block behind
 - Renamed a few internal methods to reflect what they do
 - Added debug and error logs in a few places
 - Introduced a `LakeError` enum using `thiserror` (#42), but not exposing it yet to avoid breaking changes to the framework (for now, it will be done in `0.7.0`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.0...HEAD)
 
+- Refactor internal methods: drop redundant loop, rename some functions to reflect what they do, provide more logs and proper error handling
+- Introduce the `LakeError` structure for further drop of the `anyhow` (#42). **NB!** Not exposed yet to avoid introducing another breaking change. Used only internally for now.
+
 ## [0.6.0](https://github.com/near/near-lake-framework/compare/v0.5.2...0.6.0)
 
 - Upgrade underlying dependency `near-indexer-primitives` to versions between 0.15 and 0.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.0...HEAD)
 
-- Refactor internal methods: drop redundant loop, rename some functions to reflect what they do, provide more logs and proper error handling
-- Introduce the `LakeError` structure for further drop of the `anyhow` (#42). **NB!** Not exposed yet to avoid introducing another breaking change. Used only internally for now.
+- Renamed a few internal methods to reflect what they do
+- Added debug and error logs in a few places
+- Introduced a `LakeError` enum using `thiserror` (#42), but not exposing it yet to avoid breaking changes to the framework (for now, it will be done in `0.7.0`)
+- Added proper error handling in a few places
+- Updated the dependencies version of AWS crates
 
 ## [0.6.0](https://github.com/near/near-lake-framework/compare/v0.5.2...0.6.0)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,15 @@ version = "0.6.0"
 
 [dependencies]
 anyhow = "1.0.51"
-aws-config = "0.13.0"
-aws-types = "0.13.0"
-aws-sdk-s3 = "0.13.0"
+aws-config = "0.53.0"
+aws-types = "0.53.0"
+aws-credential-types = "0.53.0"
+aws-sdk-s3 = "0.23.0"
 derive_builder = "0.11.2"
 futures = "0.3.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.75"
+thiserror = "1.0.38"
 tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ tokio = { version = "1.1", features = ["sync", "time", "macros", "rt-multi-threa
 tokio-stream = { version = "0.1" }
 
 # NEAR Lake Framework
-near-lake-framework = "0.3.0"
+near-lake-framework = "0.6.1"
 ```
 
 ## Cost estimates
@@ -129,4 +129,5 @@ The price depends on the number of shards
 We use Milestones with clearly defined acceptance criteria:
 
 * [x] [MVP](https://github.com/near/near-lake-framework/milestone/1)
+* [ ] [0.7 High-level update](https://github.com/near/near-lake-framework-rs/milestone/3)
 * [ ] [1.0](https://github.com/near/near-lake-framework/milestone/2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!        .expect("Failed to build LakeConfig");
 //!
 //!    // instantiate the NEAR Lake Framework Stream
-//!    let stream = near_lake_framework::streamer(config);
+//!    let (sender, stream) = near_lake_framework::streamer(config);
 //!
 //!    // read the stream events and pass them to a handler function with
 //!    // concurrency 1
@@ -29,7 +29,14 @@
 //!        .buffer_unordered(1usize);
 //!
 //!    while let Some(_handle_message) = handlers.next().await {}
+//!    drop(handlers); // close the channel so the sender will stop
 //!
+//!    // propagate errors from the sender
+//!    match sender.await {
+//!        Ok(Ok(())) => Ok(()),
+//!        Ok(Err(e)) => Err(e),
+//!        Err(e) => Err(anyhow::Error::from(e)), // JoinError
+//!    }
 //!    Ok(())
 //!}
 //!
@@ -46,9 +53,10 @@
 //!}
 //!```
 //!
-//! ## Video tutorial:
+//! ## Tutorials:
 //!
-//! <https://youtu.be/GsF7I93K-EQ>
+//! - <https://youtu.be/GsF7I93K-EQ>
+//! - [Migrating to NEAR Lake Framework](https://near-indexers.io/tutorials/lake/migrating-to-near-lake-framework) from [NEAR Indexer Framework](https://near-indexers.io/docs/projects/near-indexer-framework)
 //!
 //! ### More examples
 //!
@@ -69,7 +77,7 @@
 //! use near_lake_framework::LakeConfigBuilder;
 //!
 //! # async fn main() {
-//! let credentials = aws_types::Credentials::new(
+//! let credentials = aws_credential_types::Credentials::new(
 //!     "AKIAIOSFODNN7EXAMPLE",
 //!     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 //!     None,
@@ -103,6 +111,16 @@
 //!
 //![AWS docs: Configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 //!
+//! ### Environmental variables
+//!
+//! Alternatively, you can provide your AWS credentials via environment variables with constant names:
+//!
+//!```
+//!$ export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+//!$ AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+//!$ AWS_DEFAULT_REGION=eu-central-1
+//!```
+//!
 //!### Dependencies
 //!
 //!Add the following dependencies to your `Cargo.toml`
@@ -116,7 +134,7 @@
 //!tokio-stream = { version = "0.1" }
 //!
 //!# NEAR Lake Framework
-//!near-lake-framework = "0.3.0"
+//!near-lake-framework = "0.6.1"
 //!```
 //!
 //! ### Custom S3 storage
@@ -197,6 +215,7 @@
 //! We use Milestones with clearly defined acceptance criteria:
 //!
 //! * [x] [MVP](https://github.com/near/near-lake-framework/milestone/1)
+//! * [ ] [0.7 High-level update](https://github.com/near/near-lake-framework-rs/milestone/3)
 //! * [ ] [1.0](https://github.com/near/near-lake-framework/milestone/2)
 use aws_sdk_s3::Client;
 
@@ -209,7 +228,7 @@ use tokio::sync::mpsc::error::SendError;
 
 pub use near_indexer_primitives;
 
-pub use aws_types::Credentials;
+pub use aws_credential_types::Credentials;
 pub use types::{LakeConfig, LakeConfigBuilder};
 
 mod s3_fetchers;
@@ -255,9 +274,9 @@ fn stream_block_heights<'a: 'b, 'b>(
     async_stream::stream! {
         loop {
             tracing::debug!(target: LAKE_FRAMEWORK, "Fetching a list of blocks from S3...");
-            match s3_fetchers::list_blocks(
-                &s3_client,
-                &s3_bucket_name,
+            match s3_fetchers::list_block_heights(
+                s3_client,
+                s3_bucket_name,
                 start_from_block_height,
                 number_of_blocks_requested
             )
@@ -299,11 +318,14 @@ fn stream_block_heights<'a: 'b, 'b>(
     }
 }
 
-async fn fast_fetch_block_heights(
-    pending_block_heights: &mut std::pin::Pin<&mut impl tokio_stream::Stream<Item = u64>>,
+// The only consumer of the BlockHeights Streamer
+async fn prefetch_block_heights_into_pool(
+    pending_block_heights: &mut std::pin::Pin<
+        &mut impl tokio_stream::Stream<Item = crate::types::BlockHeight>,
+    >,
     limit: usize,
     await_for_at_least_one: bool,
-) -> anyhow::Result<Vec<u64>> {
+) -> anyhow::Result<Vec<crate::types::BlockHeight>> {
     let mut block_heights = Vec::with_capacity(limit);
     for remaining_limit in (0..limit).rev() {
         tracing::debug!(target: LAKE_FRAMEWORK, "Polling for the next block height without awaiting... (up to {} block heights are going to be fetched)", remaining_limit);
@@ -339,8 +361,6 @@ async fn start(
     streamer_message_sink: mpsc::Sender<near_indexer_primitives::StreamerMessage>,
     config: LakeConfig,
 ) -> anyhow::Result<()> {
-    let mut start_from_block_height = config.start_block_height;
-
     let s3_client = if let Some(config) = config.s3_config {
         Client::from_conf(config)
     } else {
@@ -353,108 +373,124 @@ async fn start(
 
     let mut last_processed_block_hash: Option<near_indexer_primitives::CryptoHash> = None;
 
-    loop {
-        let pending_block_heights = stream_block_heights(
-            &s3_client,
-            &config.s3_bucket_name,
-            start_from_block_height,
-            config.blocks_preload_pool_size * 2,
-        );
-        tokio::pin!(pending_block_heights);
+    let pending_block_heights = stream_block_heights(
+        &s3_client,
+        &config.s3_bucket_name,
+        config.start_block_height,
+        config.blocks_preload_pool_size * 2,
+    );
+    tokio::pin!(pending_block_heights);
 
-        let mut streamer_messages_futures = futures::stream::FuturesOrdered::new();
-        tracing::debug!(
-            target: LAKE_FRAMEWORK,
-            "Prefetching up to {} blocks...",
-            config.blocks_preload_pool_size
-        );
+    let mut streamer_messages_futures = futures::stream::FuturesOrdered::new();
+    tracing::debug!(
+        target: LAKE_FRAMEWORK,
+        "Prefetching up to {} blocks...",
+        config.blocks_preload_pool_size
+    );
 
-        let is_blocks_preload_pool_empty = streamer_messages_futures.is_empty();
-        streamer_messages_futures.extend(
-            fast_fetch_block_heights(
-                &mut pending_block_heights,
-                config.blocks_preload_pool_size,
-                is_blocks_preload_pool_empty,
-            )
-            .await?
-            .into_iter()
-            .map(|block_height| {
-                s3_fetchers::fetch_streamer_message(
-                    &s3_client,
-                    &config.s3_bucket_name,
-                    block_height,
-                )
-            }),
-        );
+    streamer_messages_futures.extend(
+        prefetch_block_heights_into_pool(
+            &mut pending_block_heights,
+            config.blocks_preload_pool_size,
+            true,
+        )
+        .await?
+        .into_iter()
+        .map(|block_height| {
+            s3_fetchers::fetch_streamer_message(&s3_client, &config.s3_bucket_name, block_height)
+        }),
+    );
 
-        tracing::debug!(
-            target: LAKE_FRAMEWORK,
-            "Awaiting for the first prefetched block..."
-        );
-        while let Some(streamer_message_result) = streamer_messages_futures.next().await {
-            let streamer_message = streamer_message_result?;
-            tracing::debug!(
-                target: LAKE_FRAMEWORK,
-                "Received block #{} ({})",
-                streamer_message.block.header.height,
-                streamer_message.block.header.hash
-            );
-            // check if we have `last_processed_block_hash` (might be None only on start)
-            if let Some(prev_block_hash) = last_processed_block_hash {
-                // compare last_processed_block_hash` with `block.header.prev_hash` of the current
-                // block (ensure we don't miss anything from S3)
-                // retrieve the data from S3 if prev_hashes don't match and repeat the main loop step
-                if prev_block_hash != streamer_message.block.header.prev_hash {
-                    tracing::warn!(
-                        target: LAKE_FRAMEWORK,
-                        "`prev_hash` does not match, refetching the data from S3 in 200ms",
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-                    break;
-                }
+    tracing::debug!(
+        target: LAKE_FRAMEWORK,
+        "Awaiting for the first prefetched block..."
+    );
+    while let Some(streamer_message_result) = streamer_messages_futures.next().await {
+        // log the error and throw it
+        let streamer_message = match streamer_message_result {
+            Ok(res) => res,
+            Err(err) => {
+                tracing::error!(
+                    target: LAKE_FRAMEWORK,
+                    "Failed to fetch StreamerMessage with error: \n{:#?}",
+                    err,
+                );
+                anyhow::bail!(err);
             }
-
-            // store current block info as `last_processed_block_*` for next iteration
-            last_processed_block_hash = Some(streamer_message.block.header.hash);
-            start_from_block_height = streamer_message.block.header.height + 1;
-
-            tracing::debug!(
-                target: LAKE_FRAMEWORK,
-                "Prefetching up to {} blocks... (there are {} blocks in the prefetching pool)",
-                config.blocks_preload_pool_size,
-                streamer_messages_futures.len(),
-            );
-
-            let blocks_preload_pool_current_len = streamer_messages_futures.len();
-            streamer_messages_futures.extend(
-                fast_fetch_block_heights(
-                    &mut pending_block_heights,
-                    config
-                        .blocks_preload_pool_size
-                        .saturating_sub(blocks_preload_pool_current_len),
-                    blocks_preload_pool_current_len == 0,
-                )
-                .await?
-                .into_iter()
-                .map(|block_height| {
-                    s3_fetchers::fetch_streamer_message(
-                        &s3_client,
-                        &config.s3_bucket_name,
-                        block_height,
-                    )
-                }),
-            );
-
-            tracing::debug!(
-                target: LAKE_FRAMEWORK,
-                "Streaming block #{} ({})",
-                streamer_message.block.header.height,
-                streamer_message.block.header.hash
-            );
-            if let Err(SendError(_)) = streamer_message_sink.send(streamer_message).await {
-                tracing::debug!(target: LAKE_FRAMEWORK, "Channel closed, exiting");
-                return Ok(());
+        };
+        tracing::debug!(
+            target: LAKE_FRAMEWORK,
+            "Received block #{} ({})",
+            streamer_message.block.header.height,
+            streamer_message.block.header.hash
+        );
+        // check if we have `last_processed_block_hash` (might be None only on start)
+        if let Some(prev_block_hash) = last_processed_block_hash {
+            // compare last_processed_block_hash` with `block.header.prev_hash` of the current
+            // block (ensure we don't miss anything from S3)
+            // retrieve the data from S3 if prev_hashes don't match and repeat the main loop step
+            if prev_block_hash != streamer_message.block.header.prev_hash {
+                tracing::warn!(
+                    target: LAKE_FRAMEWORK,
+                    "`prev_hash` does not match, refetching the data from S3 in 200ms",
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                break;
             }
         }
+
+        // store current block info as `last_processed_block_*` for next iteration
+        last_processed_block_hash = Some(streamer_message.block.header.hash);
+
+        tracing::debug!(
+            target: LAKE_FRAMEWORK,
+            "Prefetching up to {} blocks... (there are {} blocks in the prefetching pool)",
+            config.blocks_preload_pool_size,
+            streamer_messages_futures.len(),
+        );
+        tracing::debug!(
+            target: LAKE_FRAMEWORK,
+            "Streaming block #{} ({})",
+            streamer_message.block.header.height,
+            streamer_message.block.header.hash
+        );
+        let blocks_preload_pool_current_len = streamer_messages_futures.len();
+
+        let prefetched_block_heights_future = prefetch_block_heights_into_pool(
+            &mut pending_block_heights,
+            config
+                .blocks_preload_pool_size
+                .saturating_sub(blocks_preload_pool_current_len),
+            blocks_preload_pool_current_len == 0,
+        );
+
+        let streamer_message_sink_send_future = streamer_message_sink.send(streamer_message);
+
+        let (prefetch_res, send_res): (
+            Result<Vec<types::BlockHeight>, anyhow::Error>,
+            Result<_, SendError<near_indexer_primitives::StreamerMessage>>,
+        ) = futures::join!(
+            prefetched_block_heights_future,
+            streamer_message_sink_send_future,
+        );
+
+        if let Err(SendError(err)) = send_res {
+            tracing::error!(
+                target: LAKE_FRAMEWORK,
+                "Failed to send StreamerMessage to the channel. \n{:?}",
+                err,
+            );
+            tracing::debug!(target: LAKE_FRAMEWORK, "Channel closed, exiting");
+            return Ok(());
+        }
+
+        streamer_messages_futures.extend(prefetch_res?.into_iter().map(|block_height| {
+            s3_fetchers::fetch_streamer_message(&s3_client, &config.s3_bucket_name, block_height)
+        }));
     }
+    tracing::error!(
+        target: LAKE_FRAMEWORK,
+        "Unexpected behavior! Stream of blocks has ended, expected to be infinite",
+    );
+    anyhow::bail!("Unexpected behavior! Stream of blocks has ended, expected to be infinite");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@
 //!        Ok(Err(e)) => Err(e),
 //!        Err(e) => Err(anyhow::Error::from(e)), // JoinError
 //!    }
-//!    Ok(())
 //!}
 //!
 //! // The handler function to take the entire `StreamerMessage`

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -1,26 +1,31 @@
 use std::str::FromStr;
 
 use aws_sdk_s3::Client;
-use futures::stream::StreamExt;
 
 const ESTIMATED_SHARDS_COUNT: usize = 4;
 
 /// Queries the list of the objects in the bucket, grouped by "/" delimiter.
-/// Returns the list of blocks that can be fetched
-pub(crate) async fn list_blocks(
+/// Returns the list of block heights that can be fetched
+pub(crate) async fn list_block_heights(
     s3_client: &Client,
     s3_bucket_name: &str,
     start_from_block_height: crate::types::BlockHeight,
     number_of_blocks_requested: usize,
-) -> anyhow::Result<Vec<crate::types::BlockHeight>> {
+) -> Result<
+    Vec<crate::types::BlockHeight>,
+    crate::types::LakeError<aws_sdk_s3::error::ListObjectsV2Error>,
+> {
     tracing::debug!(
         target: crate::LAKE_FRAMEWORK,
-        "Fetching blocks from S3, after {}...",
+        "Fetching block heights from S3, after #{}...",
         start_from_block_height
     );
     let response = s3_client
         .list_objects_v2()
-        .max_keys((number_of_blocks_requested * (1 + ESTIMATED_SHARDS_COUNT)).try_into()?)
+        .max_keys(std::cmp::min(
+            (number_of_blocks_requested * (1 + ESTIMATED_SHARDS_COUNT)).try_into()?,
+            1000i32,
+        ))
         .delimiter("/".to_string())
         .start_after(format!("{:0>12}", start_from_block_height))
         .request_payer(aws_sdk_s3::model::RequestPayer::Requester)
@@ -55,9 +60,12 @@ pub(crate) async fn fetch_streamer_message(
     s3_client: &Client,
     s3_bucket_name: &str,
     block_height: crate::types::BlockHeight,
-) -> anyhow::Result<near_indexer_primitives::StreamerMessage> {
+) -> Result<
+    near_indexer_primitives::StreamerMessage,
+    crate::types::LakeError<aws_sdk_s3::error::GetObjectError>,
+> {
     let block_view = {
-        let response = loop {
+        let body_bytes = loop {
             match s3_client
                 .get_object()
                 .bucket(s3_bucket_name)
@@ -66,7 +74,19 @@ pub(crate) async fn fetch_streamer_message(
                 .send()
                 .await
             {
-                Ok(response) => break response,
+                Ok(response) => {
+                    match response.body.collect().await {
+                        Ok(bytes_stream) => break bytes_stream.into_bytes(),
+                        Err(err) => {
+                            tracing::debug!(
+                                target: crate::LAKE_FRAMEWORK,
+                                "Failed to read bytes from the block #{:0>12} response. Retrying immediately.\n{:#?}",
+                                block_height,
+                                err,
+                            );
+                        }
+                    };
+                }
                 Err(err) => {
                     tracing::debug!(
                         target: crate::LAKE_FRAMEWORK,
@@ -75,21 +95,18 @@ pub(crate) async fn fetch_streamer_message(
                         err
                     );
                 }
-            }
+            };
         };
-
-        let body_bytes = response.body.collect().await?.into_bytes();
 
         serde_json::from_slice::<near_indexer_primitives::views::BlockView>(body_bytes.as_ref())?
     };
 
-    let shards: Vec<near_indexer_primitives::IndexerShard> = (0..block_view.chunks.len() as u64)
+    let fetch_shards_futures = (0..block_view.chunks.len() as u64)
         .collect::<Vec<u64>>()
         .into_iter()
-        .map(|shard_id| fetch_shard_or_retry(s3_client, s3_bucket_name, block_height, shard_id))
-        .collect::<futures::stream::FuturesOrdered<_>>()
-        .collect()
-        .await;
+        .map(|shard_id| fetch_shard_or_retry(s3_client, s3_bucket_name, block_height, shard_id));
+
+    let shards = futures::future::try_join_all(fetch_shards_futures).await?;
 
     Ok(near_indexer_primitives::StreamerMessage {
         block: block_view,
@@ -103,7 +120,10 @@ async fn fetch_shard_or_retry(
     s3_bucket_name: &str,
     block_height: crate::types::BlockHeight,
     shard_id: u64,
-) -> near_indexer_primitives::IndexerShard {
+) -> Result<
+    near_indexer_primitives::IndexerShard,
+    crate::types::LakeError<aws_sdk_s3::error::GetObjectError>,
+> {
     loop {
         match s3_client
             .get_object()
@@ -129,25 +149,9 @@ async fn fetch_shard_or_retry(
                     }
                 };
 
-                let indexer_shard = match serde_json::from_slice::<
+                break Ok(serde_json::from_slice::<
                     near_indexer_primitives::IndexerShard,
-                >(body_bytes.as_ref())
-                {
-                    Ok(indexer_shard) => indexer_shard,
-                    Err(err) => {
-                        tracing::debug!(
-                            target: crate::LAKE_FRAMEWORK,
-                            "Failed to parse the {:0>12}/shard_{}.json. Retrying in 1s...\n {:#?}",
-                            block_height,
-                            shard_id,
-                            err,
-                        );
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                        continue;
-                    }
-                };
-
-                break indexer_shard;
+                >(body_bytes.as_ref())?);
             }
             Err(err) => {
                 tracing::debug!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -93,3 +93,23 @@ impl LakeConfigBuilder {
         self
     }
 }
+
+#[allow(clippy::enum_variant_names)]
+#[derive(thiserror::Error, Debug)]
+pub enum LakeError<E> {
+    #[error("Failed to parse structure from JSON: {error_message}")]
+    ParseError {
+        #[from]
+        error_message: serde_json::Error,
+    },
+    #[error("AWS S3 error")]
+    AwsError {
+        #[from]
+        error: aws_sdk_s3::types::SdkError<E>,
+    },
+    #[error("Failed to convert integer")]
+    IntConversionError {
+        #[from]
+        error: std::num::TryFromIntError,
+    },
+}


### PR DESCRIPTION
In this PR I am doing a few tweaks here and there:

- ~~Dropped a redundant loop that was left after the Block Heights "buffer" feature introduction~~ (that loop appears to be needed)
- Renamed a few internal methods to reflect what they do
- Added debug and error logs in a few places
- Introduced a `LakeError` enum using `thiserror` (#42), but not exposing it yet to avoid breaking changes to the framework (for now, will be added to [0.7.0](https://github.com/near/near-lake-framework-rs/milestone/3))
- Added proper error handling in a few places
- Updated the dependencies version of AWS crates

I am aiming for these changes to be released soon in the `0.6.1` version