### PR TITLE
chore: Update NEAR Lake Framework to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.0...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.1...HEAD)
+
+## [0.6.1](https://github.com/near/near-lake-framework/compare/v0.6.0...0.6.1)
 
 - Fix of possible silent stops of the streamer (firing logs and returning errors where necessary)
 - Fix the issue the streamer was always 1 block behind

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.58.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
 anyhow = "1.0.51"


### PR DESCRIPTION
## [0.6.1](https://github.com/near/near-lake-framework/compare/v0.6.0...0.6.1)

- Fix of possible silent stops of the streamer (firing logs and returning errors where necessary)
- Fix the issue the streamer was always 1 block behind
- Renamed a few internal methods to reflect what they do
- Added debug and error logs in a few places
- Introduced a `LakeError` enum using `thiserror` (#42), but not exposing it yet to avoid breaking changes to the framework (for now, it will be done in `0.7.0`)
- Added proper error handling in a few places
- Updated the dependencies version of AWS crates