### PR TITLE
feat: Support Meta transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.1...HEAD)
 
+- Add support for Meta Transactions [NEP-366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md) by upgrading `near-indexer-primitives` to `0.16`
+
+### Breaking change
+
+- `Delegate` action has been introduced in `near-primitives::views::ActionView`, this should be handled everywhere you are handling `ActionView`
+
 ## [0.6.1](https://github.com/near/near-lake-framework/compare/v0.6.0...0.6.1)
 
 - Fix of possible silent stops of the streamer (firing logs and returning errors where necessary)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.6.1...HEAD)
 
 - Add support for Meta Transactions [NEP-366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md) by upgrading `near-indexer-primitives` to `0.16`
+- Add helper function for connecting to `betanet` lake
 
 ### Breaking change
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
-near-indexer-primitives = ">=0.15.0,<0.16.0"
+near-indexer-primitives = "0.16.0"
 async-stream = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
-near-indexer-primitives = "0.16.0"
+near-indexer-primitives = ">=0.16.0,<0.17.0"
 async-stream = "0.3.3"

--- a/src/types.rs
+++ b/src/types.rs
@@ -92,6 +92,24 @@ impl LakeConfigBuilder {
         self.s3_region_name = Some("eu-central-1".to_string());
         self
     }
+
+    /// Shortcut to set up [LakeConfigBuilder::s3_bucket_name] for betanet
+    /// ```
+    /// use near_lake_framework::LakeConfigBuilder;
+    ///
+    /// # async fn main() {
+    ///    let config = LakeConfigBuilder::default()
+    ///        .betanet()
+    ///        .start_block_height(82422587)
+    ///        .build()
+    ///        .expect("Failed to build LakeConfig");
+    /// # }
+    /// ```
+    pub fn betanet(mut self) -> Self {
+        self.s3_bucket_name = Some("near-lake-data-betanet".to_string());
+        self.s3_region_name = Some("eu-central-1".to_string());
+        self
+    }
 }
 
 #[allow(clippy::enum_variant_names)]


### PR DESCRIPTION
This PR adds support for the new meta transactions/delegate actions by upgrading `near-indexer-primitives`. This is a breaking change as the `ActionView` `enum` now has the new `Delegate` variant which must be handled.

I've also added a helper method to connecting to `betanet` Lake, similar to what we have for `mainnet`/`testnet`. This will help with testing meta transactions.