### PR TITLE
test: Meta transaction deserialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,22 @@ jobs:
       run: |
         cargo clippy
 
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+        components: clippy
+    - name: Run tests
+      run: |
+        cargo test
+
   publish:
     runs-on: ubuntu-20.04
     needs: [rustfmt, rustclippy]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.0...HEAD)
 
+- Refactor `s3_fetchers` to allow testing
+
 ## [0.7.0](https://github.com/near/near-lake-framework/compare/v0.6.1...0.7.0)
 
 - Add support for Meta Transactions [NEP-366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md) by upgrading `near-indexer-primitives` to `0.16`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ aws-config = "0.53.0"
 aws-types = "0.53.0"
 aws-credential-types = "0.53.0"
 aws-sdk-s3 = "0.23.0"
+async-stream = "0.3.3"
+async-trait = "0.1.64"
 derive_builder = "0.11.2"
 futures = "0.3.23"
 serde = { version = "1", features = ["derive"] }
@@ -30,4 +32,3 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
 near-indexer-primitives = ">=0.16.0,<0.17.0"
-async-stream = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ near-indexer-primitives = ">=0.16.0,<0.17.0"
 
 [dev-dependencies]
 aws-smithy-http = "0.53.0"
+
+[lib]
+doctest = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
 near-indexer-primitives = ">=0.16.0,<0.17.0"
+
+[dev-dependencies]
+aws-smithy-http = "0.53.0"

--- a/blocks/000000879765/block.json
+++ b/blocks/000000879765/block.json
@@ -1,0 +1,63 @@
+{
+  "author": "test.near",
+  "header": {
+    "height": 879765,
+    "prev_height": 879764,
+    "epoch_id": "Hp4sw9ZGSceYadnvh7NpYJVVK7rcdir48jfrsxvwKQu9",
+    "next_epoch_id": "4h5mecoLYVFeZxAMAX3Mq3GQfEnuvSAPPo9kEpr4rGUL",
+    "hash": "95K8Je1iAVqieVU8ZuGgSdbvYs8T9rL6ER1XnRekMGbj",
+    "prev_hash": "9Da84RTsubZPcLxzK1K6JkCnDnMn4DxaSRzJPtnYJXUM",
+    "prev_state_root": "6zDM1UGLsZ7HnyUofDrTF73gv5vk2N614ViDkXBkq4ej",
+    "chunk_receipts_root": "9ETNjrt6MkwTgSVMMbpukfxRshSD1avBUUa4R4NuqwHv",
+    "chunk_headers_root": "4otZ2Zj1wANZweh33kWETr3VbF3HwW9zWET4YRYTo2pL",
+    "chunk_tx_root": "9rdfzfYzJMZyaj2yMvjget2ZsPNbZhKqY1qUXc1urDfu",
+    "outcome_root": "7tkzFg8RHBmMw1ncRJZCCZAizgq4rwCftTKYLce8RU8t",
+    "chunks_included": 1,
+    "challenges_root": "11111111111111111111111111111111",
+    "timestamp": 1676913656724153000,
+    "timestamp_nanosec": "1676913656724153000",
+    "random_value": "Au7bq9XzGAhDm2wb4PxbXQnTngzVTcWYa76Govx6n7NK",
+    "validator_proposals": [],
+    "chunk_mask": [
+      true
+    ],
+    "gas_price": "100000000",
+    "block_ordinal": 879714,
+    "rent_paid": "0",
+    "validator_reward": "0",
+    "total_supply": "2085303629225498163419972383984892",
+    "challenges_result": [],
+    "last_final_block": "BS9QJenf3N9pKy8PZ5xRuowZi9X9T4sSDDu4i3i5UJZe",
+    "last_ds_final_block": "9Da84RTsubZPcLxzK1K6JkCnDnMn4DxaSRzJPtnYJXUM",
+    "next_bp_hash": "EtsYQonaJ7n5nRt32XJC5dBxxBxh7a9UVApykmmt8fCQ",
+    "block_merkle_root": "CqRoDd8BR4su7Z8vSfvg45HrugZnwbMbnXHRTWYQkWfZ",
+    "epoch_sync_data_hash": null,
+    "approvals": [
+      "ed25519:3RBQ4PnfBbnDn8WnCScQJH9asjkicuhZZo36aa6FVa2Lbnj531NLiBkTmj8rhg5vfsarmYLgQmcMcXRuJ4jkzKns"
+    ],
+    "signature": "ed25519:2dWsY1QadJyNaVkyga5Wcj9DFRizAyFc9STjyN5Mtxc59ZzNYqML6qQTgtLeCYkpCy1h7kG34jcALTpEDQpkBoKQ",
+    "latest_protocol_version": 59
+  },
+  "chunks": [
+    {
+      "chunk_hash": "7Ewp1AnL6o29UXLW2up9miQBdSaKxCnfRyhMGt9G4epN",
+      "prev_block_hash": "9Da84RTsubZPcLxzK1K6JkCnDnMn4DxaSRzJPtnYJXUM",
+      "outcome_root": "11111111111111111111111111111111",
+      "prev_state_root": "2ViDp7rmam77VmhY5C9KW92a6mgUTCKQ3Scz8tFyH13z",
+      "encoded_merkle_root": "44MrDjQzt1jU5PGUYY69THZ4g3SsfQiNiKKorey3GVtq",
+      "encoded_length": 364,
+      "height_created": 879765,
+      "height_included": 879765,
+      "shard_id": 0,
+      "gas_used": 0,
+      "gas_limit": 1000000000000000,
+      "rent_paid": "0",
+      "validator_reward": "0",
+      "balance_burnt": "0",
+      "outgoing_receipts_root": "H4Rd6SGeEBTbxkitsCdzfu9xL9HtZ2eHoPCQXUeZ6bW4",
+      "tx_root": "GKd8Evs3JdahRpS8q14q6RzzkodzFiSQPcH4yJxs4ZjG",
+      "validator_proposals": [],
+      "signature": "ed25519:2qev3mWQdYLi9aPwCnFHt22GFxhuGTGfnaz3msGcduUdXeycTQDBkY4EyQzpph4frXCybuYHE6g4GFxD2HVmWbJY"
+    }
+  ]
+}

--- a/blocks/000000879765/shard_0.json
+++ b/blocks/000000879765/shard_0.json
@@ -1,0 +1,239 @@
+{
+  "shard_id": 0,
+  "chunk": {
+    "author": "test.near",
+    "header": {
+      "chunk_hash": "7Ewp1AnL6o29UXLW2up9miQBdSaKxCnfRyhMGt9G4epN",
+      "prev_block_hash": "9Da84RTsubZPcLxzK1K6JkCnDnMn4DxaSRzJPtnYJXUM",
+      "outcome_root": "11111111111111111111111111111111",
+      "prev_state_root": "2ViDp7rmam77VmhY5C9KW92a6mgUTCKQ3Scz8tFyH13z",
+      "encoded_merkle_root": "44MrDjQzt1jU5PGUYY69THZ4g3SsfQiNiKKorey3GVtq",
+      "encoded_length": 364,
+      "height_created": 879765,
+      "height_included": 0,
+      "shard_id": 0,
+      "gas_used": 0,
+      "gas_limit": 1000000000000000,
+      "rent_paid": "0",
+      "validator_reward": "0",
+      "balance_burnt": "0",
+      "outgoing_receipts_root": "H4Rd6SGeEBTbxkitsCdzfu9xL9HtZ2eHoPCQXUeZ6bW4",
+      "tx_root": "GKd8Evs3JdahRpS8q14q6RzzkodzFiSQPcH4yJxs4ZjG",
+      "validator_proposals": [],
+      "signature": "ed25519:2qev3mWQdYLi9aPwCnFHt22GFxhuGTGfnaz3msGcduUdXeycTQDBkY4EyQzpph4frXCybuYHE6g4GFxD2HVmWbJY"
+    },
+    "transactions": [
+      {
+        "transaction": {
+          "signer_id": "test.near",
+          "public_key": "ed25519:8Rn4FJeeRYcrLbcrAQNFVgvbZ2FCEQjgydbXwqBwF1ib",
+          "nonce": 39,
+          "receiver_id": "test.near",
+          "actions": [
+            {
+              "Delegate": {
+                "delegate_action": {
+                  "sender_id": "test.near",
+                  "receiver_id": "test.near",
+                  "actions": [
+                    {
+                      "AddKey": {
+                        "public_key": "ed25519:CnQMksXTTtn81WdDujsEMQgKUMkFvDJaAjDeDLTxVrsg",
+                        "access_key": {
+                          "nonce": 0,
+                          "permission": "FullAccess"
+                        }
+                      }
+                    }
+                  ],
+                  "nonce": 879546,
+                  "max_block_height": 100,
+                  "public_key": "ed25519:8Rn4FJeeRYcrLbcrAQNFVgvbZ2FCEQjgydbXwqBwF1ib"
+                },
+                "signature": "ed25519:25uGrsJNU3fVgUpPad3rGJRy2XQum8gJxLRjKFCbd7gymXwUxQ9r3tuyBCD6To7SX5oSJ2ScJZejwqK1ju8WdZfS"
+              }
+            }
+          ],
+          "signature": "ed25519:3vKF31u2naSjow1uQEfkoWy834fu9xhk66oBfTAYL3XVtJVAf1FREt7owJzwyRrN5F4mtd1rkvv1iTPTL86Szb2j",
+          "hash": "EZnJpyJDnkwnadB1V8PqjVMx7oe2zLhUMtJ8v6EUh1NQ"
+        },
+        "outcome": {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "7kPZTTVYJHvUg4g3S7SFErkKs18Ex1kN4rESnZwtJb2U",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "95K8Je1iAVqieVU8ZuGgSdbvYs8T9rL6ER1XnRekMGbj",
+            "id": "EZnJpyJDnkwnadB1V8PqjVMx7oe2zLhUMtJ8v6EUh1NQ",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [
+                "AQDQ9G4QpK7x2inV3GieVEbqeoCGF9nmvrViQ2UgEXDQ"
+              ],
+              "gas_burnt": 409824625000,
+              "tokens_burnt": "40982462500000000000",
+              "executor_id": "test.near",
+              "status": {
+                "SuccessReceiptId": "AQDQ9G4QpK7x2inV3GieVEbqeoCGF9nmvrViQ2UgEXDQ"
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": null
+              }
+            }
+          },
+          "receipt": null
+        }
+      }
+    ],
+    "receipts": [
+      {
+        "predecessor_id": "test.near",
+        "receiver_id": "test.near",
+        "receipt_id": "AQDQ9G4QpK7x2inV3GieVEbqeoCGF9nmvrViQ2UgEXDQ",
+        "receipt": {
+          "Action": {
+            "signer_id": "test.near",
+            "signer_public_key": "ed25519:8Rn4FJeeRYcrLbcrAQNFVgvbZ2FCEQjgydbXwqBwF1ib",
+            "gas_price": "100000000",
+            "output_data_receivers": [],
+            "input_data_ids": [],
+            "actions": [
+              {
+                "Delegate": {
+                  "delegate_action": {
+                    "sender_id": "test.near",
+                    "receiver_id": "test.near",
+                    "actions": [
+                      {
+                        "AddKey": {
+                          "public_key": "ed25519:CnQMksXTTtn81WdDujsEMQgKUMkFvDJaAjDeDLTxVrsg",
+                          "access_key": {
+                            "nonce": 0,
+                            "permission": "FullAccess"
+                          }
+                        }
+                      }
+                    ],
+                    "nonce": 879546,
+                    "max_block_height": 100,
+                    "public_key": "ed25519:8Rn4FJeeRYcrLbcrAQNFVgvbZ2FCEQjgydbXwqBwF1ib"
+                  },
+                  "signature": "ed25519:25uGrsJNU3fVgUpPad3rGJRy2XQum8gJxLRjKFCbd7gymXwUxQ9r3tuyBCD6To7SX5oSJ2ScJZejwqK1ju8WdZfS"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "receipt_execution_outcomes": [
+    {
+      "execution_outcome": {
+        "proof": [
+          {
+            "hash": "6vBgNYcwx6pcESfrw5YRBRamatBH8red3GEt3s3ntefm",
+            "direction": "Left"
+          }
+        ],
+        "block_hash": "95K8Je1iAVqieVU8ZuGgSdbvYs8T9rL6ER1XnRekMGbj",
+        "id": "AQDQ9G4QpK7x2inV3GieVEbqeoCGF9nmvrViQ2UgEXDQ",
+        "outcome": {
+          "logs": [],
+          "receipt_ids": [
+            "5rc8UEhD4hmNQ3pJJM5Xc3VHeLXpCQqkA3ep8ag4aaDA"
+          ],
+          "gas_burnt": 308059500000,
+          "tokens_burnt": "30805950000000000000",
+          "executor_id": "test.near",
+          "status": {
+            "Failure": {
+              "ActionError": {
+                "index": 0,
+                "kind": "DelegateActionExpired"
+              }
+            }
+          },
+          "metadata": {
+            "version": 3,
+            "gas_profile": []
+          }
+        }
+      },
+      "receipt": {
+        "predecessor_id": "test.near",
+        "receiver_id": "test.near",
+        "receipt_id": "AQDQ9G4QpK7x2inV3GieVEbqeoCGF9nmvrViQ2UgEXDQ",
+        "receipt": {
+          "Action": {
+            "signer_id": "test.near",
+            "signer_public_key": "ed25519:8Rn4FJeeRYcrLbcrAQNFVgvbZ2FCEQjgydbXwqBwF1ib",
+            "gas_price": "100000000",
+            "output_data_receivers": [],
+            "input_data_ids": [],
+            "actions": [
+              {
+                "Delegate": {
+                  "delegate_action": {
+                    "sender_id": "test.near",
+                    "receiver_id": "test.near",
+                    "actions": [
+                      {
+                        "AddKey": {
+                          "public_key": "ed25519:CnQMksXTTtn81WdDujsEMQgKUMkFvDJaAjDeDLTxVrsg",
+                          "access_key": {
+                            "nonce": 0,
+                            "permission": "FullAccess"
+                          }
+                        }
+                      }
+                    ],
+                    "nonce": 879546,
+                    "max_block_height": 100,
+                    "public_key": "ed25519:8Rn4FJeeRYcrLbcrAQNFVgvbZ2FCEQjgydbXwqBwF1ib"
+                  },
+                  "signature": "ed25519:25uGrsJNU3fVgUpPad3rGJRy2XQum8gJxLRjKFCbd7gymXwUxQ9r3tuyBCD6To7SX5oSJ2ScJZejwqK1ju8WdZfS"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "state_changes": [
+    {
+      "cause": {
+        "type": "transaction_processing",
+        "tx_hash": "EZnJpyJDnkwnadB1V8PqjVMx7oe2zLhUMtJ8v6EUh1NQ"
+      },
+      "type": "account_update",
+      "change": {
+        "account_id": "test.near",
+        "amount": "999999549946933447300000000000000",
+        "locked": "81773107345435833494396250588347",
+        "code_hash": "11111111111111111111111111111111",
+        "storage_usage": 182,
+        "storage_paid_at": 0
+      }
+    },
+    {
+      "cause": {
+        "type": "transaction_processing",
+        "tx_hash": "EZnJpyJDnkwnadB1V8PqjVMx7oe2zLhUMtJ8v6EUh1NQ"
+      },
+      "type": "access_key_update",
+      "change": {
+        "account_id": "test.near",
+        "public_key": "ed25519:8Rn4FJeeRYcrLbcrAQNFVgvbZ2FCEQjgydbXwqBwF1ib",
+        "access_key": {
+          "nonce": 39,
+          "permission": "FullAccess"
+        }
+      }
+    }
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,8 @@ pub use near_indexer_primitives;
 pub use aws_credential_types::Credentials;
 pub use types::{LakeConfig, LakeConfigBuilder};
 
+use s3_fetchers::LakeClient;
+
 mod s3_fetchers;
 pub(crate) mod types;
 
@@ -265,7 +267,7 @@ pub fn streamer(
 }
 
 fn stream_block_heights<'a: 'b, 'b>(
-    s3_client: &'a Client,
+    lake_client: &'a LakeClient,
     s3_bucket_name: &'a str,
     mut start_from_block_height: crate::types::BlockHeight,
 ) -> impl futures::Stream<Item = u64> + 'b {
@@ -273,7 +275,7 @@ fn stream_block_heights<'a: 'b, 'b>(
         loop {
             tracing::debug!(target: LAKE_FRAMEWORK, "Fetching a list of blocks from S3...");
             match s3_fetchers::list_block_heights(
-                s3_client,
+                lake_client,
                 s3_bucket_name,
                 start_from_block_height,
             )
@@ -370,6 +372,7 @@ async fn start(
             .build();
         Client::from_conf(s3_config)
     };
+    let lake_client = s3_fetchers::LakeClient::new(s3_client.clone());
 
     let mut last_processed_block_hash: Option<near_indexer_primitives::CryptoHash> = None;
 
@@ -381,8 +384,11 @@ async fn start(
         // in some cases, write N+1 block before it finishes writing the N block.
         // We require to stream blocks consistently, so we need to try to load the block again.
 
-        let pending_block_heights =
-            stream_block_heights(&s3_client, &config.s3_bucket_name, start_from_block_height);
+        let pending_block_heights = stream_block_heights(
+            &lake_client,
+            &config.s3_bucket_name,
+            start_from_block_height,
+        );
         tokio::pin!(pending_block_heights);
 
         let mut streamer_messages_futures = futures::stream::FuturesOrdered::new();
@@ -402,7 +408,7 @@ async fn start(
             .into_iter()
             .map(|block_height| {
                 s3_fetchers::fetch_streamer_message(
-                    &s3_client,
+                    &lake_client,
                     &config.s3_bucket_name,
                     block_height,
                 )
@@ -502,12 +508,13 @@ async fn start(
                     })?
                     .into_iter()
                     .map(|block_height| {
-                s3_fetchers::fetch_streamer_message(
-                    &s3_client,
-                    &config.s3_bucket_name,
-                    block_height,
-                )
-            }));
+                        s3_fetchers::fetch_streamer_message(
+                            &lake_client,
+                            &config.s3_bucket_name,
+                            block_height,
+                        )
+                    }
+            ));
         }
 
         tracing::warn!(

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -1,6 +1,26 @@
+use async_trait::async_trait;
 use std::str::FromStr;
 
 use aws_sdk_s3::Client;
+use aws_sdk_s3::output::{GetObjectOutput, ListObjectsV2Output};
+
+#[async_trait]
+pub trait LakeS3Client {
+    async fn get_object(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Result<GetObjectOutput, aws_sdk_s3::types::SdkError<aws_sdk_s3::error::GetObjectError>>;
+
+    async fn list_objects(
+        &self,
+        bucket: &str,
+        start_after: &str,
+    ) -> Result<
+        ListObjectsV2Output,
+        aws_sdk_s3::types::SdkError<aws_sdk_s3::error::ListObjectsV2Error>,
+    >;
+}
 
 /// Queries the list of the objects in the bucket, grouped by "/" delimiter.
 /// Returns the list of block heights that can be fetched


### PR DESCRIPTION
This PR introduces tests for `s3_fetchers`, with the goal of testing the deserialization of meta transactions. It does this by creating a new `trait` to abstract away `aws_sdk_s3::Client` providing the ability to inject fake implementations which have mock S3 responses.

I've also added another step to the existing github action which will run the tests.