### PR TITLE
fix: Betanet shortcut default region fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.0...HEAD)
 
 - Refactor `s3_fetchers` to allow testing
+- Fix `betanet` default region (the corresponding bucket is in different region)
 
 ## [0.7.0](https://github.com/near/near-lake-framework/compare/v0.6.1...0.7.0)
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -107,7 +107,7 @@ impl LakeConfigBuilder {
     /// ```
     pub fn betanet(mut self) -> Self {
         self.s3_bucket_name = Some("near-lake-data-betanet".to_string());
-        self.s3_region_name = Some("eu-central-1".to_string());
+        self.s3_region_name = Some("us-east-1".to_string());
         self
     }
 }


### PR DESCRIPTION
The PR https://github.com/near/near-lake-framework-rs/pull/57 enabling a new shortcut for `betanet` assumed the corresponding S3 bucket will be created in the same region as the other buckets. 
Surprisingly, the `near-lake-data-betanet` was created in a different region and the shortcut became broken.
This PR fixes it and adds a corresponding changelog record so we can create and publish a minor release (0.7.1)