### PR TITLE
chore: Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.0...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.1...HEAD)
+
+## [0.7.1](https://github.com/near/near-lake-framework/compare/v0.7.1...0.7.0)
 
 - Refactor `s3_fetchers` to allow testing
 - Fix `betanet` default region (the corresponding bucket is in different region)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.58.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.0"
+version = "0.7.1"
 
 [dependencies]
 anyhow = "1.0.51"


### PR DESCRIPTION
This is a minor release that basically allows you to run an indexer against `betanet` (if you need, of course, we need it)