### PR TITLE
chore: README cost estimates. Fix year, explain magic numbers a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ tokio-stream = { version = "0.1" }
 near-lake-framework = "0.6.1"
 ```
 
-## Cost estimates (Updated Mar 10, 2022 with more precise calculations)
+## Cost estimates (Updated Mar 10, 2023 with more precise calculations)
 
 **TL;DR** approximately $20 per month (for AWS S3 access, paid directly to AWS) for the reading of fresh blocks
 
@@ -111,6 +111,10 @@ near-lake-framework = "0.6.1"
 | 77,021,059 | 385105295 | 308084.236 | 165.5952769 | 1.663654874 | $167.26 |
 
 **Note:** ~77m of blocks is the number of blocks on the moment I was calculating.
+
+**84,400 blocks is approximate number of blocks per day** (1 block per second * 60 seconds * 60 minutes * 24 hours)
+
+**2,592,000 blocks is approximate number of blocks per months** (86,400 blocks per day * 30 days)
 
 ### Tip of the network indexing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,10 @@
 //!
 //! **Note:** ~77m of blocks is the number of blocks on the moment I was calculating.
 //!
+// !**84,400 blocks is approximate number of blocks per day** (1 block per second * 60 seconds * 60 minutes * 24 hours)
+//!
+//! **2,592,000 blocks is approximate number of blocks per months** (86,400 blocks per day * 30 days)
+//!
 //! ### Tip of the network indexing
 //!
 //! | Blocks | GET | LIST | Subtotal GET | Subtotal LIST | Total $ |


### PR DESCRIPTION
- Fixed a year (2022 -> 2023, I seem to be living in the past)
- Added notes explaining the magic numbers (number of blocks per day, per month)