### PR TITLE
fix(tests): Resolved #60: Fix failing doc tests

### DIFF
--- a/lake-framework/README.md
+++ b/lake-framework/README.md
@@ -6,49 +6,26 @@ the NEAR Protocol data.
 
 ## Example
 
-```ignore
-use futures::StreamExt;
-use near_lake_framework::LakeConfigBuilder;
-
-#[tokio::main]
-async fn main() -> Result<(), tokio::io::Error> {
-    // create a NEAR Lake Framework config
-    let config = LakeConfigBuilder::default()
+```no_run
+fn main() -> anyhow::Result<()> {
+    near_lake_framework::LakeBuilder::default()
         .testnet()
-        .start_block_height(82422587)
-        .build()
-        .expect("Failed to build LakeConfig");
-
-    // instantiate the NEAR Lake Framework Stream
-    let (sender, stream) = near_lake_framework::streamer(config);
-
-    // read the stream events and pass them to a handler function with
-    // concurrency 1
-    let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)
-        .map(|streamer_message| handle_streamer_message(streamer_message))
-        .buffer_unordered(1usize);
-
-    while let Some(_handle_message) = handlers.next().await {}
-    drop(handlers); // close the channel so the sender will stop
-
-    // propagate errors from the sender
-    match sender.await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(e)) => Err(e),
-        Err(e) => Err(anyhow::Error::from(e)), // JoinError
-    }
+        .start_block_height(112205773)
+        .build()?
+        .run(handle_block)
 }
 
-// The handler function to take the entire `StreamerMessage`
-// and print the block height and number of shards
-async fn handle_streamer_message(
-    streamer_message: near_lake_framework::near_indexer_primitives::StreamerMessage,
-) {
+// The handler function to take the `Block`
+// and print the block height
+async fn handle_block(
+    block: near_lake_primitives::block::Block,
+    _context: near_lake_framework::LakeContext,
+) -> anyhow::Result<()> {
     eprintln!(
-        "{} / shards {}",
-        streamer_message.block.header.height,
-        streamer_message.shards.len()
+        "Block #{}",
+        block.block_height(),
     );
+#    Ok(())
 }
 ```
 
@@ -73,10 +50,10 @@ In order to be able to get objects from the AWS S3 bucket you need to provide th
 
 #### Passing credentials to the config builder
 
-```rust
+```
 use near_lake_framework::LakeBuilder;
 
-# async fn main() {
+# fn main() {
 let credentials = aws_credential_types::Credentials::new(
     "AKIAIOSFODNN7EXAMPLE",
     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -88,9 +65,10 @@ let s3_config = aws_sdk_s3::Config::builder()
     .credentials_provider(credentials)
     .build();
 
-let config = LakeBuilder::default()
+let lake = LakeBuilder::default()
     .s3_config(s3_config)
     .s3_bucket_name("near-lake-data-custom")
+    .s3_region_name("eu-central-1")
     .start_block_height(1)
     .build()
     .expect("Failed to build LakeConfig");
@@ -125,7 +103,7 @@ $ AWS_DEFAULT_REGION=eu-central-1
 
 Add the following dependencies to your `Cargo.toml`
 
-```toml
+```text
 ...
 [dependencies]
 futures = "0.3.5"
@@ -134,7 +112,7 @@ tokio = { version = "1.1", features = ["sync", "time", "macros", "rt-multi-threa
 tokio-stream = { version = "0.1" }
 
 # NEAR Lake Framework
-near-lake-framework = "0.6.1"
+near-lake-framework = "0.8.0"
 ```
 
 ### Custom S3 storage
@@ -148,24 +126,22 @@ In case you want to run your own [near-lake](https://github.com/near/near-lake) 
 $ mkdir -p /data/near-lake-custom && minio server /data
 ```
 
- - pass custom `aws_sdk_s3::config::Config` to the [LakeConfigBuilder]
+ - pass custom `aws_sdk_s3::config::Config` to the [LakeBuilder]
 
-```rust
-use aws_sdk_s3::Endpoint;
-use http::Uri;
+```
 use near_lake_framework::LakeBuilder;
 
-# fn main() {
+# #[tokio::main]
+# async fn main() {
 let aws_config = aws_config::from_env().load().await;
-let mut s3_conf = aws_sdk_s3::config::Builder::from(&aws_config);
-s3_conf = s3_conf
-    .endpoint_resolver(
-        Endpoint::immutable("http://0.0.0.0:9000".parse::<Uri>().unwrap()))
+let mut s3_conf = aws_sdk_s3::config::Builder::from(&aws_config)
+    .endpoint_url("http://0.0.0.0:9000")
     .build();
 
-let config = LakeBuilder::default()
+let lake = LakeBuilder::default()
     .s3_config(s3_conf)
     .s3_bucket_name("near-lake-data-custom")
+    .s3_region_name("eu-central-1")
     .start_block_height(1)
     .build()
     .expect("Failed to build LakeConfig");

--- a/lake-framework/README.md
+++ b/lake-framework/README.md
@@ -50,7 +50,7 @@ In order to be able to get objects from the AWS S3 bucket you need to provide th
 
 #### Passing credentials to the config builder
 
-```
+```rust
 use near_lake_framework::LakeBuilder;
 
 # fn main() {
@@ -103,7 +103,7 @@ $ AWS_DEFAULT_REGION=eu-central-1
 
 Add the following dependencies to your `Cargo.toml`
 
-```text
+```toml
 ...
 [dependencies]
 futures = "0.3.5"
@@ -122,7 +122,7 @@ In case you want to run your own [near-lake](https://github.com/near/near-lake) 
 
  - run minio
 
-```text
+```bash
 $ mkdir -p /data/near-lake-custom && minio server /data
 ```
 

--- a/lake-framework/src/lib.rs
+++ b/lake-framework/src/lib.rs
@@ -16,24 +16,17 @@ pub(crate) mod types;
 pub(crate) const LAKE_FRAMEWORK: &str = "near_lake_framework";
 
 /// Creates `mpsc::channel` and returns the `receiver` to read the stream of `StreamerMessage`
-/// ```
-/// use near_lake_framework::LakeConfigBuilder;
-/// use tokio::sync::mpsc;
-///
-/// # async fn main() {
-///    let config = LakeConfigBuilder::default()
+///```no_run
+///# fn main() -> anyhow::Result<()> {
+///    near_lake_framework::LakeBuilder::default()
 ///        .testnet()
-///        .start_block_height(82422587)
-///        .build()
-///        .expect("Failed to build LakeConfig");
+///        .start_block_height(112205773)
+///        .build()?
+///        .run(handle_block)
+///# }
 ///
-///     let (_, stream) = near_lake_framework::streamer(config);
-///
-///     while let Some(streamer_message) = stream.recv().await {
-///         eprintln!("{:#?}", streamer_message);
-///     }
-/// # }
-/// ```
+/// # async fn handle_block(_block: near_lake_primitives::block::Block, _context: near_lake_framework::LakeContext) -> anyhow::Result<()> { Ok(()) }
+///```
 impl types::Lake {
     pub fn run<Fut>(
         self,

--- a/lake-framework/src/types.rs
+++ b/lake-framework/src/types.rs
@@ -2,17 +2,17 @@
 pub type BlockHeight = u64;
 
 /// Configuration struct for NEAR Lake Framework
-/// NB! Consider using [`LakeConfigBuilder`]
-/// Building the `LakeConfig` example:
+/// NB! Consider using [`LakeBuilder`]
+/// Building the `Lake` example:
 /// ```
-/// use near_lake_framework::LakeConfigBuilder;
+/// use near_lake_framework::LakeBuilder;
 ///
-/// # async fn main() {
-///    let config = LakeConfigBuilder::default()
+/// # fn main() {
+///    let lake = LakeBuilder::default()
 ///        .testnet()
 ///        .start_block_height(82422587)
 ///        .build()
-///        .expect("Failed to build LakeConfig");
+///        .expect("Failed to build Lake");
 /// # }
 /// ```
 #[derive(Default, Builder, Debug)]
@@ -30,24 +30,22 @@ pub struct Lake {
     /// ## Use-case: custom endpoint
     /// You might want to stream data from the custom S3-compatible source () . In order to do that you'd need to pass `aws_sdk_s3::config::Config` configured
     /// ```
-    /// use aws_sdk_s3::Endpoint;
-    /// use http::Uri;
-    /// use near_lake_framework::LakeConfigBuilder;
+    /// use near_lake_framework::LakeBuilder;
     ///
+    /// # #[tokio::main]
     /// # async fn main() {
     ///     let aws_config = aws_config::from_env().load().await;
-    ///     let mut s3_conf = aws_sdk_s3::config::Builder::from(&aws_config);
-    ///     s3_conf = s3_conf
-    ///         .endpoint_resolver(
-    ///             Endpoint::immutable("http://0.0.0.0:9000".parse::<Uri>().unwrap()))
+    ///     let mut s3_conf = aws_sdk_s3::config::Builder::from(&aws_config)
+    ///         .endpoint_url("http://0.0.0.0:9000")
     ///         .build();
     ///
-    ///     let config = LakeConfigBuilder::default()
+    ///     let lake = LakeBuilder::default()
     ///         .s3_config(s3_conf)
     ///         .s3_bucket_name("near-lake-data-custom")
+    ///         .s3_region_name("eu-central-1")
     ///         .start_block_height(1)
     ///         .build()
-    ///         .expect("Failed to build LakeConfig");
+    ///         .expect("Failed to build Lake");
     /// # }
     /// ```
     #[builder(setter(strip_option), default)]
@@ -57,16 +55,16 @@ pub struct Lake {
 }
 
 impl LakeBuilder {
-    /// Shortcut to set up [LakeConfigBuilder::s3_bucket_name] for mainnet
+    /// Shortcut to set up [LakeBuilder::s3_bucket_name] for mainnet
     /// ```
-    /// use near_lake_framework::LakeConfigBuilder;
+    /// use near_lake_framework::LakeBuilder;
     ///
-    /// # async fn main() {
-    ///    let config = LakeConfigBuilder::default()
+    /// # fn main() {
+    ///    let lake = LakeBuilder::default()
     ///        .mainnet()
     ///        .start_block_height(65231161)
     ///        .build()
-    ///        .expect("Failed to build LakeConfig");
+    ///        .expect("Failed to build Lake");
     /// # }
     /// ```
     pub fn mainnet(mut self) -> Self {
@@ -75,16 +73,16 @@ impl LakeBuilder {
         self
     }
 
-    /// Shortcut to set up [LakeConfigBuilder::s3_bucket_name] for testnet
+    /// Shortcut to set up [LakeBuilder::s3_bucket_name] for testnet
     /// ```
-    /// use near_lake_framework::LakeConfigBuilder;
+    /// use near_lake_framework::LakeBuilder;
     ///
-    /// # async fn main() {
-    ///    let config = LakeConfigBuilder::default()
+    /// # fn main() {
+    ///    let lake = LakeBuilder::default()
     ///        .testnet()
     ///        .start_block_height(82422587)
     ///        .build()
-    ///        .expect("Failed to build LakeConfig");
+    ///        .expect("Failed to build Lake");
     /// # }
     /// ```
     pub fn testnet(mut self) -> Self {
@@ -93,16 +91,16 @@ impl LakeBuilder {
         self
     }
 
-    /// Shortcut to set up [LakeConfigBuilder::s3_bucket_name] for betanet
+    /// Shortcut to set up [LakeBuilder::s3_bucket_name] for betanet
     /// ```
-    /// use near_lake_framework::LakeConfigBuilder;
+    /// use near_lake_framework::LakeBuilder;
     ///
-    /// # async fn main() {
-    ///    let config = LakeConfigBuilder::default()
+    /// # fn main() {
+    ///    let lake = LakeBuilder::default()
     ///        .betanet()
     ///        .start_block_height(82422587)
     ///        .build()
-    ///        .expect("Failed to build LakeConfig");
+    ///        .expect("Failed to build Lake");
     /// # }
     /// ```
     pub fn betanet(mut self) -> Self {


### PR DESCRIPTION
This PR is aiming at the `dev-0.8.8` branch and updates the READMEs, fixes code examples to pass doc tests.

BTW partially resolving #52 (Lake Framework documentation update, though might be changed closer to the release)

The output looks perfect :)
```
     Running unittests src/lib.rs (target/debug/deps/near_lake_framework-32dcaeaff76ac223)

running 1 test
test s3_fetchers::test::deserializes_meta_transactions ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/near_lake_primitives-2c87358ec0ad3e20)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests near-lake-framework

running 11 tests
test src/lib.rs - types::Lake (line 19) - compile ... ok
test src/types.rs - types::Lake (line 7) ... ok
test src/types.rs - types::LakeBuilder::mainnet (line 59) ... ok
test src/lib.rs - (line 9) - compile ... ok
test src/types.rs - types::LakeBuilder::betanet (line 95) ... ok
test src/lib.rs - (line 53) ... ok
test src/types.rs - types::LakeBuilder::s3_config (line 32) ... ok
test src/types.rs - types::LakeBuilder::s3_config (line 32) ... ok
test src/types.rs - types::LakeBuilder::testnet (line 77) ... ok
test src/lib.rs - (line 131) ... ok
test src/types.rs - types::Lake::s3_config (line 32) ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.44s

   Doc-tests near-lake-primitives

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```