### PR TITLE
feat: Expose concurrency parameter to the Lake structure (and builder)

### DIFF
--- a/lake-framework/src/lib.rs
+++ b/lake-framework/src/lib.rs
@@ -38,6 +38,9 @@ impl types::Lake {
         let runtime = tokio::runtime::Runtime::new()?;
 
         runtime.block_on(async {
+            // capture the concurrency value before it moves into the streamer
+            let concurrency = self.concurrency;
+
             // instantiate the NEAR Lake Framework Stream
             let (sender, stream) = streamer::streamer(self);
 
@@ -49,7 +52,7 @@ impl types::Lake {
                     let block: near_lake_primitives::block::Block = streamer_message.into();
                     f(block, context).await
                 })
-                .buffer_unordered(1usize);
+                .buffer_unordered(concurrency);
 
             while let Some(_handle_message) = handlers.next().await {}
             drop(handlers); // close the channel so the sender will stop

--- a/lake-framework/src/types.rs
+++ b/lake-framework/src/types.rs
@@ -50,8 +50,18 @@ pub struct Lake {
     /// ```
     #[builder(setter(strip_option), default)]
     pub(crate) s3_config: Option<aws_sdk_s3::config::Config>,
+    /// Defines how many *block heights* Lake Framework will try to preload into memory to avoid S3 `List` requests.
+    /// Default: 100
+    ///
+    /// *Note*: This value is not the number of blocks to preload, but the number of block heights.
+    /// Also, this value doesn't affect your indexer much if it follows the tip of the network.
+    /// This parameter is useful for historical indexing.
     #[builder(default = "100")]
     pub(crate) blocks_preload_pool_size: usize,
+    /// Number of concurrent blocks to process. Default: 1
+    /// **WARNING**: Increase this value only if your block handling logic doesn't have to rely on previous blocks and can be processed in parallel
+    #[builder(default = "1")]
+    pub(crate) concurrency: usize,
 }
 
 impl LakeBuilder {


### PR DESCRIPTION
We used to have a hardcoded value for the block-processing concurrency. It was 1 by default since it is the most convenient for most indexers since most block-processing logic depends on the previous blocks.

Today, we expose a configuration parameter for the `concurrency` (default is still `1`).

```rust
LakeBuild::default()
    .mainnet()
    .start_block_height(0)
    .concurrency(1_000)
    .build()
    .unwrap()
    .run(handle_block)
```

Please be aware that the concurrency should be increased only if your block-processing logic is independent of the previously processed blocks. Otherwise, your indexer will be stuck.