### PR TITLE
feat: LEP-071 Introduce middlewares concept

### DIFF
--- a/lake-framework/Cargo.toml
+++ b/lake-framework/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.0.0" # managed by cargo-workspaces
 edition = "2021"
 
 [dependencies]
+async-stream = "0.3.3"
+async-trait = "0.1.68"
 aws-config = "0.53.0"
 aws-types = "0.53.0"
 aws-credential-types = "0.53.0"
 aws-sdk-s3 = "0.23.0"
-async-stream = "0.3.3"
-async-trait = "0.1.64"
 derive_builder = "0.11.2"
 futures = "0.3.23"
 serde = { version = "1", features = ["derive"] }

--- a/lake-framework/examples/middleware_simple.rs
+++ b/lake-framework/examples/middleware_simple.rs
@@ -1,0 +1,37 @@
+//! A simple example of how to use the Lake Framework with middlewares
+//! This indexer will listen to the NEAR blockchain and print the block height of each block
+//! Though the print will be done by the middleware, not the handler
+
+// Using the async_trait re-exported from the framework
+use near_lake_framework::async_trait::async_trait;
+use near_lake_framework::near_lake_primitives;
+
+#[derive(Debug, Default)]
+struct PrinterMiddleware;
+
+#[async_trait]
+impl near_lake_framework::LakeMiddleware for PrinterMiddleware {
+    async fn process(
+        &self,
+        block: near_lake_primitives::block::Block,
+    ) -> near_lake_primitives::block::Block {
+        println!("Block {:?}", block.block_height());
+        block
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    eprintln!("Starting...");
+    // Lake Framework start boilerplate
+    near_lake_framework::LakeBuilder::default()
+        .testnet()
+        .start_block_height(112205773)
+        .middleware(PrinterMiddleware::default())
+        .build()?
+        .run(handle_block)?; // developer-defined async function that handles each block
+    Ok(())
+}
+
+async fn handle_block(_block: near_lake_primitives::block::Block) -> anyhow::Result<()> {
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces the concept of middlewares proposed in LEP-071(#71).

An example with the simplest possible middleware is included (`lake-framework/examples/middleware_simple.rs`)

Here's how it looks:

```rust
#[derive(Debug, Default)]
struct PrinterMiddleware;

#[async_trait]
impl near_lake_framework::LakeMiddleware for PrinterMiddleware {
    async fn process(
        &self,
        block: near_lake_primitives::block::Block,
    ) -> near_lake_primitives::block::Block {
        println!("Block {:?}", block.block_height());
        block
    }
}

...

near_lake_framework::LakeBuilder::default()
    .testnet()
    .start_block_height(112205773)
    .middleware(PrinterMiddleware::default())
//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    .build()?
    .run(handle_block)?;

...
```

Along with the implementation of proposal, I am planning to create the very first shareable middleware `ParentTransactionCache` described in the proposal (#71)