### PR TITLE
feat: ParentTransactionCache context and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,12 @@
 members = [
     "lake-framework",
     "lake-primitives",
+    "lake-parent-transaction-cache",
 ]
 
 # cargo-workspaces
 [workspace.package]
-version = "0.6.0"
+version = "0.8.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-lake-framework"
 description = "Library to connect to the NEAR Lake S3 and stream the data"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "lake-framework",
     "lake-primitives",
     "lake-parent-transaction-cache",
+    "lake-context-derive",
 ]
 
 # cargo-workspaces

--- a/lake-context-derive/Cargo.toml
+++ b/lake-context-derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lake-context-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0"
+quote = "1.0"

--- a/lake-context-derive/README.md
+++ b/lake-context-derive/README.md
@@ -1,0 +1,51 @@
+# Lake Context Derive
+
+Lake Context Derive is a Rust crate that provides a derive macro for easy and convenient implementation of the `near_lake_framework::LakeContextExt` trait. This trait has two functions: `execute_before_run` and `execute_after_run` that are executed before and after the user-provided indexer function respectively.
+
+## Usage
+
+The Lake Context Derive macro can be utilized by annotating the context struct with `#[derive(LakeContext)]`. This trait implementation will then facilitate the combination of different contexts. For instance, to use a `ParentTransactionCache` with some additional data, one would define a context like:
+
+```no_run
+use lake_parent_transaction_cache::ParentTransactionCache;
+
+#[derive(LakeContext)]
+struct MyContext {
+  db_connection_string: String,
+  parent_tx_cache: ParentTransactionCache,
+}
+```
+
+### Instantiation
+
+You can create an instance of your context as follows:
+
+```no_run
+let my_context = MyContext {
+  db_connection_string: String::from("postgres://user:pass@host/db"),
+  parent_tx_cache: ParentTransactionCache::default().build().unwrap(),
+};
+```
+
+### User Indexer Function
+
+This will simplify your indexer function signature. It now needs only the context as an additional parameter:
+
+```no_run
+async fn handle_block(
+    mut block: Block,
+    ctx: &MyContext,
+) -> anyhow::Result<()> {
+  // body
+}
+```
+
+The Lake Context Derive will look for all fields in the struct that implement `LakeContextExt`, and will append their trait methods to the top-level calls. For `execute_before_run`, it is done in ascending order, and for `execute_after_run` in descending order.
+
+## Purpose
+
+The purpose of the Lake Context Derive crate is to alleviate some of the common pain points in context development and usage in Rust. By encapsulating and standardizing the handling of these function calls, we aim to create a more accessible and user-friendly approach to context implementation.
+
+## Collaboration
+
+We hope that this tool will be useful for the Rust community and look forward to seeing how it can be used in a range of different projects. We encourage community contributions, whether that's through sharing your own unique context implementations or by providing feedback and suggestions for how we can continue to improve the Lake Context Derive.

--- a/lake-context-derive/src/lib.rs
+++ b/lake-context-derive/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 use proc_macro::TokenStream;
 use quote::quote;
 

--- a/lake-context-derive/src/lib.rs
+++ b/lake-context-derive/src/lib.rs
@@ -1,0 +1,79 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+#[proc_macro_derive(LakeContext)]
+pub fn lake_context_derive(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    // Used in the quasi-quotation below as `#name`.
+    let name = input.ident;
+
+    // Build the trait impl.
+    // Iterate over all fields and for each field generate a call to `execute_before_run`.
+    // if the field is a an impl of LakeContext, then call `execute_before_run` on the struct.
+
+    let fields = if let syn::Data::Struct(syn::DataStruct {
+        fields: syn::Fields::Named(syn::FieldsNamed { named, .. }),
+        ..
+    }) = &input.data
+    {
+        named
+    } else {
+        unimplemented!();
+    };
+
+    let calls_before_run = fields
+        .iter()
+        .filter(|f| {
+            let ty = &f.ty;
+            if let syn::Type::Path(syn::TypePath { path, .. }) = ty {
+                if let Some(ident) = path.get_ident() {
+                    ident == "LakeContext"
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        })
+        .map(|f| {
+            let name = &f.ident;
+            quote! { self.#name.execute_before_run(block); }
+        });
+
+    let calls_after_run = fields
+        .iter()
+        .rev()
+        .filter(|f| {
+            let ty = &f.ty;
+            if let syn::Type::Path(syn::TypePath { path, .. }) = ty {
+                if let Some(ident) = path.get_ident() {
+                    ident == "LakeContext"
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        })
+        .map(|f| {
+            let name = &f.ident;
+            quote! { self.#name.execute_after_run(); }
+        });
+
+    let expanded = quote! {
+        // The generated impl.
+        impl near_lake_framework::LakeContextExt for #name {
+            fn execute_before_run(&self, block: &mut near_lake_primitives::block::Block) {
+                #( #calls_before_run )*
+            }
+
+            fn execute_after_run(&self) {
+                #( #calls_after_run )*
+            }
+        }
+    };
+
+    // Hand the output tokens back to the compiler.
+    proc_macro::TokenStream::from(expanded)
+}

--- a/lake-framework/Cargo.toml
+++ b/lake-framework/Cargo.toml
@@ -20,6 +20,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
 near-lake-primitives = { path = "../lake-primitives" }
+lake-context-derive = { path = "../lake-context-derive" }
 
 [dev-dependencies]
 aws-smithy-http = "0.53.0"

--- a/lake-framework/Cargo.toml
+++ b/lake-framework/Cargo.toml
@@ -29,3 +29,6 @@ anyhow = "1.0.51"
 # used by nft_indexer example
 regex = "1.5.4"
 once_cell = "1.8.0"
+
+# used by with_context_parent_tx_cache example
+lake-parent-transaction-cache = { path = "../lake-parent-transaction-cache" }

--- a/lake-framework/Cargo.toml
+++ b/lake-framework/Cargo.toml
@@ -31,5 +31,8 @@ anyhow = "1.0.51"
 regex = "1.5.4"
 once_cell = "1.8.0"
 
+# used in the doc examples
+diesel = { version = "2", features= ["postgres_backend", "postgres"] }
+
 # used by with_context_parent_tx_cache example
 lake-parent-transaction-cache = { path = "../lake-parent-transaction-cache" }

--- a/lake-framework/README.md
+++ b/lake-framework/README.md
@@ -67,6 +67,58 @@ async fn handle_block(
 }
 ```
 
+## Parent Transaction for the Receipt Context
+
+It is an old problem that the NEAR Protocol doesn't provide the parent transaction hash in the receipt. This is a problem for the indexer that needs to know the parent transaction hash to build the transaction tree. We've got you covered with the [`lake-parent-transaction-cache`](../lake-parent-transaction-cache/) crate that provides a cache for the parent transaction hashes.
+
+```no_run
+use near_lake_framework::near_lake_primitives;
+use near_lake_primitives::CryptoHash;
+use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
+use near_lake_primitives::actions::ActionMetaDataExt;
+
+fn main() -> anyhow::Result<()> {
+    let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
+        .build()?;
+    // Lake Framework start boilerplate
+    near_lake_framework::LakeBuilder::default()
+        .mainnet()
+        .start_block_height(88444526)
+        .build()?
+        // developer-defined async function that handles each block
+        .run_with_context(print_function_call_tx_hash, &parent_transaction_cache_ctx)?;
+    Ok(())
+}
+
+async fn print_function_call_tx_hash(
+    mut block: near_lake_primitives::block::Block,
+    ctx: &ParentTransactionCache,
+) -> anyhow::Result<()> {
+    // Cache has been updated before this function is called.
+    let block_height = block.block_height();
+    let actions: Vec<(
+        &near_lake_primitives::actions::FunctionCall,
+        Option<CryptoHash>,
+    )> = block
+        .actions()
+        .filter_map(|action| action.as_function_call())
+        .map(|action| {
+            (
+                action,
+                ctx.get_parent_transaction_hash(&action.receipt_id()),
+            )
+        })
+        .collect();
+
+    if !actions.is_empty() {
+        // Here's the usage of the context.
+        println!("Block #{:?}\n{:#?}", block_height, actions);
+    }
+
+    Ok(())
+}
+```
+
 ## Tutorials:
 
  - <https://youtu.be/GsF7I93K-EQ>

--- a/lake-framework/README.md
+++ b/lake-framework/README.md
@@ -32,6 +32,7 @@ async fn handle_block(
 ### Pass the context to the function
 
 ```no_run
+#[derive(near_lake_framework::LakeContext)]
 struct MyContext {
     my_field: String
 }

--- a/lake-framework/examples/with_context.rs
+++ b/lake-framework/examples/with_context.rs
@@ -8,6 +8,13 @@ use near_lake_primitives::actions::ActionMetaDataExt;
 
 const CONTRACT_ID: &str = "social.near";
 
+// This is the context we're going to use.
+// Lake::run_with_context requires the context to implement the LakeContext trait.
+// That trait requires to implement two methods `execute_before_run` and `execute_after_run`.
+// However, we don't actually need them in our cause of using the context.
+// That's why we're using the derive macro to implement the trait for us.
+// The macro will generate the default implementation of the methods. Those methods are empty.
+// By doing so, we don't need to implement the trait manually and can use the context as is.
 #[derive(Clone, LakeContext)]
 struct FileContext {
     path: std::path::PathBuf,

--- a/lake-framework/examples/with_context.rs
+++ b/lake-framework/examples/with_context.rs
@@ -1,15 +1,14 @@
 //! This example show how to use a context with Lake Framework.
 //! It is going to follow the NEAR Social contract and the block height along
 //! with a number of calls to the contract.
+use near_lake_framework::{near_lake_primitives, LakeContext};
 use std::io::Write;
-
-use near_lake_framework::near_lake_primitives;
 // We need to import this trait to use the `as_function_call` method.
 use near_lake_primitives::actions::ActionMetaDataExt;
 
 const CONTRACT_ID: &str = "social.near";
 
-#[derive(Clone)]
+#[derive(Clone, LakeContext)]
 struct FileContext {
     path: std::path::PathBuf,
 }

--- a/lake-framework/examples/with_context_parent_tx_cache.rs
+++ b/lake-framework/examples/with_context_parent_tx_cache.rs
@@ -1,0 +1,62 @@
+//! This example show how to use a context ParentTransactionCache with the Lake Framework.
+//! It is going to follow the NEAR Social contract and cache the parent Transaction for the Receipts.
+//! Thus we would be able to capture the Transaction where the change to the contract state has started.
+//! **WARNING**: ParentTransactionCache captures all the transactions in the block.
+//! That's why we filter it by only one account we're watching here.
+use near_lake_framework::near_lake_primitives;
+use near_lake_primitives::CryptoHash;
+// We need to import this trait to use the `as_function_call` method.
+use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
+use near_lake_primitives::actions::ActionMetaDataExt;
+
+const CONTRACT_ID: &str = "social.near";
+
+fn main() -> anyhow::Result<()> {
+    println!("Starting...");
+    // Building the ParentTransactionCache context.
+    // The way of instantiation of the context depends on the implementation developers choose.
+    // ParentTransactionCache follows the Builder pattern.
+    // This will create the context with the default size of the cache (100_000)
+    // and a filter for the account we're watching.
+    // It will omit caching all the transactions that are not related to the account.
+    let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
+        .for_account(String::from(CONTRACT_ID).try_into()?)
+        .build()?;
+    // Lake Framework start boilerplate
+    near_lake_framework::LakeBuilder::default()
+        .mainnet()
+        .start_block_height(88444526)
+        .build()?
+        // developer-defined async function that handles each block
+        .run_with_context(print_function_call_tx_hash, &parent_transaction_cache_ctx)?;
+    Ok(())
+}
+
+async fn print_function_call_tx_hash(
+    mut block: near_lake_primitives::block::Block,
+    ctx: &ParentTransactionCache,
+) -> anyhow::Result<()> {
+    ctx.update_cache(&mut block); // Call it as early as possible to have an updated cache.
+    let block_height = block.block_height();
+    let actions: Vec<(
+        &near_lake_primitives::actions::FunctionCall,
+        Option<CryptoHash>,
+    )> = block
+        .actions()
+        .filter(|action| action.receiver_id().as_str() == CONTRACT_ID)
+        .filter_map(|action| action.as_function_call())
+        .map(|action| {
+            (
+                action,
+                ctx.get_parent_transaction_hash(&action.receipt_id()),
+            )
+        })
+        .collect();
+
+    if !actions.is_empty() {
+        // Here's the usage of the context.
+        println!("Block #{:?}\n{:#?}", block_height, actions);
+    }
+
+    Ok(())
+}

--- a/lake-framework/examples/with_context_parent_tx_cache.rs
+++ b/lake-framework/examples/with_context_parent_tx_cache.rs
@@ -36,7 +36,7 @@ async fn print_function_call_tx_hash(
     mut block: near_lake_primitives::block::Block,
     ctx: &ParentTransactionCache,
 ) -> anyhow::Result<()> {
-    ctx.update_cache(&mut block); // Call it as early as possible to have an updated cache.
+    // Cache has been updated before this function is called.
     let block_height = block.block_height();
     let actions: Vec<(
         &near_lake_primitives::actions::FunctionCall,

--- a/lake-framework/output.txt
+++ b/lake-framework/output.txt
@@ -1,2 +1,0 @@
-Block #88444775 - 2 calls to social.near
-Block #88444915 - 1 calls to social.near

--- a/lake-framework/output.txt
+++ b/lake-framework/output.txt
@@ -1,0 +1,2 @@
+Block #88444775 - 2 calls to social.near
+Block #88444915 - 1 calls to social.near

--- a/lake-framework/src/lib.rs
+++ b/lake-framework/src/lib.rs
@@ -8,7 +8,7 @@ pub use lake_context_derive::LakeContext;
 pub use near_lake_primitives::{self, near_indexer_primitives};
 
 pub use aws_credential_types::Credentials;
-pub use types::{Lake, LakeBuilder, LakeContext as LakeContextExt, LakeError};
+pub use types::{Lake, LakeBuilder, LakeContextExt, LakeError};
 
 mod s3_fetchers;
 mod streamer;
@@ -19,9 +19,13 @@ pub(crate) const LAKE_FRAMEWORK: &str = "near_lake_framework";
 impl types::Lake {
     /// Creates `mpsc::channel` and returns the `receiver` to read the stream of `StreamerMessage`
     ///```no_run
+    ///  # use near_lake_framework::{LakeContext};
+    ///
+    /// #[derive(LakeContext)]
     ///  struct MyContext {
     ///      my_field: String,
     ///  }
+    ///
     ///# fn main() -> anyhow::Result<()> {
     ///
     ///    let context = MyContext {
@@ -38,7 +42,7 @@ impl types::Lake {
     ///
     /// # async fn handle_block(_block: near_lake_primitives::block::Block, context: &MyContext) -> anyhow::Result<()> { Ok(()) }
     ///```
-    pub fn run_with_context<'context, C: types::LakeContext, E, Fut>(
+    pub fn run_with_context<'context, C: LakeContextExt, E, Fut>(
         self,
         f: impl Fn(near_lake_primitives::block::Block, &'context C) -> Fut,
         context: &'context C,

--- a/lake-framework/src/types.rs
+++ b/lake-framework/src/types.rs
@@ -156,3 +156,8 @@ pub enum LakeError {
     #[error("Internal error: {error_message}")]
     InternalError { error_message: String },
 }
+
+pub trait LakeContext {
+    fn execute_before_run(&self, block: &mut near_lake_primitives::block::Block);
+    fn execute_after_run(&self);
+}

--- a/lake-framework/src/types.rs
+++ b/lake-framework/src/types.rs
@@ -157,7 +157,168 @@ pub enum LakeError {
     InternalError { error_message: String },
 }
 
-pub trait LakeContext {
+/// ### The concept of Context for the Lake Framework
+/// The main idea of the Lake Framework is to provide a simple way to index data from the NEAR blockchain.
+/// The framework is designed to be as flexible as possible, so it doesn't provide any specific logic for indexing.
+/// Instead, it provides a way to implement your own logic. One of the main concepts of the framework is the Context.
+/// The Context is a struct that implements the [LakeContext] trait. It is used to pass data between the framework and your logic.
+/// The Context is created once and then passed to the framework. The framework will call the [LakeContext::execute_before_run]
+/// method before the indexing process starts and [LakeContext::execute_after_run] after the indexing process is finished.
+/// The Context is useful for passing data between blocks. For example, you can use it to store the last block timestamp and use it in the next block.
+///
+/// Also the Context is necessary to pass the "global" data to the indexing process. For example, you can use it to pass the database connection pool.
+///
+/// ### Examples
+///
+/// #### Simple Context examples (explicit)
+/// **WARNING**: This example demonsrates how Context works explicitly. In the real-world application you would do less boilerplate. See further examples.
+/// In this example we will create a simple Context that prints the block height before the processing the block.
+/// ```no_run
+/// use near_lake_framework::LakeContextExt; // note Lake Framework exports this trait with a suffix Ext in the name
+/// struct PrinterContext;
+///
+/// impl LakeContextExt for PrinterContext {
+///    fn execute_before_run(&self, block: &mut near_lake_primitives::block::Block) {
+///       println!("Processing block {}", block.header().height());
+///   }
+///   fn execute_after_run(&self) {}
+/// }
+/// ```
+/// As you can see we will be printing `Processing block {block_height}` before processing the block. And we will do nothing after
+///  the indexing process is finished.
+///
+/// The next example is showing how to provide some value to the indexing process.
+/// ```no_run
+/// use near_lake_framework::LakeContextExt; // note Lake Framework exports this trait with a suffix Ext in the name
+/// use near_lake_framework::LakeBuilder;
+/// # use diesel::Connection;
+///
+/// struct ApplicationDataContext {
+///    pub db_pool: diesel::pg::PgConnection,
+/// }
+///
+/// // We need our context to do nothing before and after the indexing process.
+/// // The only purpose is to provide the database connection pool to the indexing process.
+/// impl LakeContextExt for ApplicationDataContext {
+///   fn execute_before_run(&self, block: &mut near_lake_primitives::block::Block) {}
+///   fn execute_after_run(&self) {}
+/// }
+///
+/// fn main() {
+///     let db_pool = diesel::PgConnection::establish("postgres://localhost:5432")
+///        .expect("Failed to connect to database");
+///     let context = ApplicationDataContext { db_pool };
+///
+///     let result = LakeBuilder::default()
+///       .testnet()
+///       .start_block_height(82422587)
+///       .build()
+///       .unwrap()
+///       .run_with_context(indexing_function, &context);
+/// }
+///
+/// async fn indexing_function(
+///    block: near_lake_primitives::block::Block,
+///    context: &ApplicationDataContext,
+/// ) -> Result<(), near_lake_framework::LakeError> {
+///     // Now we can use the database connection pool
+///     let db_pool = &context.db_pool;
+///     ///...
+///     Ok(())
+/// }
+/// ```
+///
+/// #### Simple Context example (real-world)
+/// The last example from the previous section is a bit verbose. In the real-world application you would do less boilerplate.
+/// The main purpose of that example was to show you what's happening under the hood. However, for your convenience, the Lake Framework
+/// provides a trait [LakeContextExt] that implements the [LakeContext] trait for you. So you can use it to create a simple Context.
+///
+/// ```ignore
+/// use near_lake_framework::LakeContext; // This is a derive macro
+/// use near_lake_framework::LakeBuilder;
+///
+/// #[derive(LakeContext)]
+/// /// struct ApplicationDataContext {
+///    pub db_pool: diesel::pg::PgConnection,
+/// }
+///
+/// // Here we got rid of the boilerplate code that we had in the previous example to impl the LakeContext trait.
+///
+/// fn main() {
+///     let db_pool = diesel::pg::PgConnection::establish("postgres://postgres:password@localhost:5432/database")
+///        .unwrap_or_else(|_| panic!("Error connecting to database"))
+///
+///     let context = ApplicationDataContext { db_pool };
+///
+///     let result = LakeBuilder::default()
+///       .testnet()
+///       .start_block_height(82422587)
+///       .build()
+///       .unwrap()
+///       .run_with_context(indexing_function, &context);
+/// }
+///
+/// async fn indexing_function(
+///    block: near_lake_primitives::block::Block,
+///    context: &ApplicationDataContext,
+/// ) -> Result<(), near_lake_framework::LakeError> {
+///     // Now we can use the database connection pool
+///     let db_pool = &context.db_pool;
+///     // ...
+///    Ok(())
+/// }
+/// ```
+///
+/// It might look like not a big deal to get rid of the boilerplate code. However, it is very useful when you have a lot of Contexts or when you
+/// use a ready-to-use Context from the community.
+///
+/// #### Advanced Context example
+/// In this example we will extend a previous one with the `ParentTransactionCache` context Lake Framework team has created and shared with everybody.
+///
+/// ```no_run
+/// use near_lake_framework::LakeContext; // This is a derive macro
+/// use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder}; // This is a ready-to-use Context from the community that impls LakeContext trait
+/// use near_lake_framework::LakeBuilder;
+/// # use diesel::Connection;
+///
+/// #[derive(LakeContext)]
+/// struct ApplicationDataContext {
+///    pub db_pool: diesel::pg::PgConnection,
+///   pub parent_transaction_cache: ParentTransactionCache,
+/// }
+///
+/// fn main() {
+///     let db_pool = diesel::PgConnection::establish("postgres://postgres:password@localhost:5432/database")
+///        .unwrap_or_else(|_| panic!("Error connecting to database"));
+///     let parent_transaction_cache = ParentTransactionCacheBuilder::default().build().unwrap();
+///
+///     let context = ApplicationDataContext { db_pool, parent_transaction_cache };
+///
+///     let result = LakeBuilder::default()
+///       .testnet()
+///       .start_block_height(82422587)
+///       .build()
+///       .unwrap()
+///       .run_with_context(indexing_function, &context);
+/// }
+///
+/// async fn indexing_function(
+///    block: near_lake_primitives::block::Block,
+///    context: &ApplicationDataContext,
+/// ) -> Result<(), near_lake_framework::LakeError> {
+///     // Now we can use the database connection pool
+///     let db_pool = &context.db_pool;
+///     dbg!(&context.parent_transaction_cache);
+///     Ok(())
+/// }
+/// ```
+/// As you can see we have extended our context with the `ParentTransactionCache` context. And we can use it in our indexing function.
+/// The `ParentTransactionCache` defines the `execute_before_run` and `execute_after_run` methods. So when we call `run_with_context` method
+/// the Lake Framework will call `execute_before_run` and `execute_after_run` methods for us.
+/// And we didn't need to implement them in our `ApplicationDataContext` struct because `LakeContext` derive macro did it for us automatically.
+pub trait LakeContextExt {
+    /// This method will be called before the indexing process is started.
     fn execute_before_run(&self, block: &mut near_lake_primitives::block::Block);
+    /// This method will be called after the indexing process is finished.
     fn execute_after_run(&self);
 }

--- a/lake-parent-transaction-cache/Cargo.toml
+++ b/lake-parent-transaction-cache/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lake-parent-transaction-cache"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cached = "0.43.0"
+derive_builder = "0.12.0"
+
+near-lake-framework = { path = "../lake-framework" }
+
+[dev-dependencies]
+anyhow = "1.0.44"

--- a/lake-parent-transaction-cache/README.md
+++ b/lake-parent-transaction-cache/README.md
@@ -70,7 +70,7 @@ near_lake_framework::LakeBuilder::default()
     .mainnet()
     .start_block_height(<desired_block_height>)
     .build()?
-    .run_with_context(<you_indexing_function>, &parent_transaction_cache_ctx)?;
+    .run_with_context(<your_indexing_function>, &parent_transaction_cache_ctx)?;
 ```
 
 Replace `<desired_block_height>` with the starting block height you want to use. Replace `<you_indexing_function>` with the function you want to use to index the blocks.

--- a/lake-parent-transaction-cache/README.md
+++ b/lake-parent-transaction-cache/README.md
@@ -74,3 +74,47 @@ near_lake_framework::LakeBuilder::default()
 ```
 
 Replace `<desired_block_height>` with the starting block height you want to use. Replace `<you_indexing_function>` with the function you want to use to index the blocks.
+
+## Advanced Usage
+
+### Cache size
+
+We use [SizedCache](https://docs.rs/cached/0.43.0/cached/stores/struct.SizedCache.html) under the hood. So we can configure the cache size by using the `cache_size` method:
+
+```no_run
+# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
+    .cache_size(100_000);
+```
+
+By default the cache size is 100,000.
+
+### Watch for specific accounts
+
+By default `ParentTransactionCache` context will cache the relation between Transaction and Receipt for every Transaction in the block. But you can configure it to watch for specific accounts only:
+
+#### You can pass a Vec of AccountId
+
+```no_run
+# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+use near_lake_framework::near_primitives::types::AccountId;
+
+let accounts_to_watch: Vec<AccountId> = vec![
+    String::from("alice.near).try_into().unwrap(),
+    String::from("bob.near).try_into().unwrap(),
+];
+let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
+    .for_accounts(accounts_to_watch);
+```
+
+#### You can pass accounts to watch one by one using `for_account` method
+
+```no_run
+# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+use near_lake_framework::near_primitives::types::AccountId;
+
+let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
+    .for_account(String::from("alice.near).try_into().unwrap())
+    .for_account(String::from("bob.near).try_into().unwrap());
+```
+

--- a/lake-parent-transaction-cache/README.md
+++ b/lake-parent-transaction-cache/README.md
@@ -1,0 +1,76 @@
+# Lake Parent Transaction Cache (Context)
+
+Lake Parent Transaction Cache is a ready-to-use context for the Lake Framework in Rust. It provides a cache for keeping the relation between transactions and receipts in cache.
+
+## Example Usage
+
+```no_run
+use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
+# use near_lake_framework::LakeBuilder;
+# use near_lake_framework::near_lake_primitives::{block::Block, actions::ActionMetaDataExt};
+
+# fn main() {
+let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
+    .build()
+    .expect("Failed to build the ParentTransactionCache context");
+
+LakeBuilder::default()
+    .mainnet()
+    .start_block_height(80504433)
+    .build()
+    .expect("Failed to build the Lake Framework")
+    .run_with_context(handle_block, &parent_transaction_cache_ctx)
+    .expect("Failed to run the Lake Framework");
+# }
+
+async fn handle_block(
+    mut block: Block,
+    ctx: &ParentTransactionCache,
+) -> anyhow::Result<()> {
+    for action in block.actions() {
+        println!(
+            "Action receipt ID: {:?} | Parent TX hash: {:?}",
+            action.receipt_id(),
+            ctx.get_parent_transaction_hash(&action.receipt_id())
+        );
+    }
+    Ok(())
+}
+```
+
+## Getting Started
+
+To use the Lake Parent Transaction Cache context in your Rust project, follow these steps:
+
+1. Add the following dependencies to your `Cargo.toml` file:
+
+```toml
+[dependencies]
+lake_parent_transaction_cache = "<version>"
+```
+
+2. Import the necessary modules in your code:
+
+```ignore
+use lake_parent_transaction_cache::ParentTransactionCache;
+use near_lake_primitives::actions::ActionMetaDataExt;
+```
+
+3. Create an instance of the `ParentTransactionCache` context:
+
+```no_run
+# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default();
+```
+
+4. Configure the Lake Framework and run it with the created context:
+
+```ignore
+near_lake_framework::LakeBuilder::default()
+    .mainnet()
+    .start_block_height(<desired_block_height>)
+    .build()?
+    .run_with_context(<you_indexing_function>, &parent_transaction_cache_ctx)?;
+```
+
+Replace `<desired_block_height>` with the starting block height you want to use. Replace `<you_indexing_function>` with the function you want to use to index the blocks.

--- a/lake-parent-transaction-cache/src/lib.rs
+++ b/lake-parent-transaction-cache/src/lib.rs
@@ -22,7 +22,7 @@ pub struct ParentTransactionCache {
     )]
     cache: std::sync::RwLock<Cache>,
     #[builder(setter(custom = true, name = "for_accounts"))]
-    accounts_id: Vec<AccountId>,
+    account_ids: Vec<AccountId>,
 }
 
 impl ParentTransactionCacheBuilder {
@@ -38,7 +38,7 @@ impl ParentTransactionCacheBuilder {
     /// sender or receiver in the list of accounts.
     /// **Warning**: This method overrides the previous value.
     pub fn for_accounts(mut self, accounts_id: Vec<AccountId>) -> Self {
-        self.accounts_id = Some(accounts_id);
+        self.account_ids = Some(accounts_id);
         self
     }
 
@@ -48,11 +48,11 @@ impl ParentTransactionCacheBuilder {
     /// in the list of accounts.
     /// **Warning**: This method appends to the previous value.
     pub fn for_account(mut self, account_id: AccountId) -> Self {
-        if let Some(mut accounts_id) = self.accounts_id.take() {
+        if let Some(mut accounts_id) = self.account_ids.take() {
             accounts_id.push(account_id);
-            self.accounts_id = Some(accounts_id);
+            self.account_ids = Some(accounts_id);
         } else {
-            self.accounts_id = Some(vec![account_id]);
+            self.account_ids = Some(vec![account_id]);
         }
         self
     }
@@ -67,9 +67,9 @@ impl LakeContextExt for ParentTransactionCache {
         // We will try to skip the transactions related to the accounts we're not watching for.
         // Based on `accounts_id`
         for tx in block.transactions().filter(move |tx| {
-            self.accounts_id.is_empty()
-                || self.accounts_id.contains(tx.signer_id())
-                || self.accounts_id.contains(tx.receiver_id())
+            self.account_ids.is_empty()
+                || self.account_ids.contains(tx.signer_id())
+                || self.account_ids.contains(tx.receiver_id())
         }) {
             let tx_hash = tx.transaction_hash();
             tx.actions_included()

--- a/lake-parent-transaction-cache/src/lib.rs
+++ b/lake-parent-transaction-cache/src/lib.rs
@@ -1,0 +1,101 @@
+#![doc = include_str!("../README.md")]
+#[macro_use]
+extern crate derive_builder;
+
+use cached::{Cached, SizedCache};
+use near_lake_framework::{
+    near_indexer_primitives::{near_primitives::types::AccountId, CryptoHash},
+    near_lake_primitives::{actions::ActionMetaDataExt, block::Block},
+};
+
+pub type ReceiptId = CryptoHash;
+pub type TransactionHash = CryptoHash;
+type Cache = SizedCache<ReceiptId, TransactionHash>;
+
+#[derive(Debug, Builder)]
+#[builder(pattern = "owned")]
+pub struct ParentTransactionCache {
+    #[builder(
+        setter(custom = true, name = "cache_size"),
+        default = "std::sync::RwLock::new(Cache::with_size(100_000))"
+    )]
+    cache: std::sync::RwLock<Cache>,
+    #[builder(setter(custom = true, name = "for_accounts"))]
+    accounts_id: Vec<AccountId>,
+}
+
+impl ParentTransactionCacheBuilder {
+    /// Sets the size of the cache. Default is 100_000.
+    pub fn cache_size(mut self, value: usize) -> Self {
+        self.cache = Some(std::sync::RwLock::new(Cache::with_size(value)));
+        self
+    }
+
+    /// Stores the Vec of [AccountId](near_lake_framework::near_indexer_primitives::near_primitives::types::AccountId) to cache transactions for.
+    /// If not set, the cache will be created for all the Transactions in the block.
+    /// If set the cache will be created only for the transactions that have the
+    /// sender or receiver in the list of accounts.
+    /// **Warning**: This method overrides the previous value.
+    pub fn for_accounts(mut self, accounts_id: Vec<AccountId>) -> Self {
+        self.accounts_id = Some(accounts_id);
+        self
+    }
+
+    /// Adds an account to the watching list for the parent transaction cache.
+    /// Similarly to the method [for_accounts](#method.for_accounts) this method will
+    /// create the cache only for the transactions that have the sender or receiver
+    /// in the list of accounts.
+    /// **Warning**: This method appends to the previous value.
+    pub fn for_account(mut self, account_id: AccountId) -> Self {
+        if let Some(mut accounts_id) = self.accounts_id.take() {
+            accounts_id.push(account_id);
+            self.accounts_id = Some(accounts_id);
+        } else {
+            self.accounts_id = Some(vec![account_id]);
+        }
+        self
+    }
+}
+
+impl ParentTransactionCache {
+    /// The process to scan the [near_lake_primitives::Block](near_lake_framework::near_lake_primitives::block::Block) and update the cache
+    /// with the new transactions and first expected receipts.
+    /// The cache is used to find the parent transaction hash for a given receipt id.
+    pub fn update_cache(&self, block: &mut Block) {
+        // Fill up the cache with new transactions and first expected receipts
+        // We will try to skip the transactions related to the accounts we're not watching for.
+        // Based on `accounts_id`
+        for tx in block.transactions().filter(move |tx| {
+            self.accounts_id.is_empty()
+                || self.accounts_id.contains(tx.signer_id())
+                || self.accounts_id.contains(tx.receiver_id())
+        }) {
+            let tx_hash = tx.transaction_hash();
+            tx.actions_included()
+                .map(|action| action.metadata().receipt_id())
+                .for_each(|receipt_id| {
+                    let mut cache = self.cache.write().unwrap();
+                    cache.cache_set(receipt_id, tx_hash);
+                });
+        }
+        for receipt in block.receipts() {
+            let receipt_id = receipt.receipt_id();
+            let mut cache = self.cache.write().unwrap();
+            let parent_tx_hash = cache.cache_remove(&receipt_id);
+
+            if let Some(parent_tx_hash) = parent_tx_hash {
+                cache.cache_set(receipt_id, parent_tx_hash.clone());
+            }
+        }
+    }
+
+    /// Returns the parent transaction hash for a given receipt id.
+    /// If the receipt id is not found in the cache, it returns None.
+    /// If the receipt id is found in the cache, it returns the parent transaction hash.
+    pub fn get_parent_transaction_hash(&self, receipt_id: &ReceiptId) -> Option<TransactionHash> {
+        // **Note**: [cached::SizedCache] updates metadata on every cache access. That's why
+        // we need to use a write lock here.
+        let mut cache = self.cache.write().unwrap();
+        cache.cache_get(receipt_id).cloned()
+    }
+}

--- a/lake-primitives/README.md
+++ b/lake-primitives/README.md
@@ -1,0 +1,27 @@
+```markdown
+# NEAR Lake Primitives
+
+NEAR Lake Primitives is a Rust crate that provides a set of high-level primitives specifically designed for the NEAR Lake Framework. It is part of the effort to streamline and facilitate the development of blockchain applications within the NEAR ecosystem.
+
+## Features
+
+The crate offers a range of fundamental primitives, or basic components, that developers can use to build more complex structures and processes within the NEAR Lake Framework. These primitives are optimized for efficient computation and robust interoperability.
+
+## Usage
+
+To use the NEAR Lake Primitives in your Rust project, add the following line to your `Cargo.toml` file:
+
+```toml
+[dependencies]
+near_lake_primitives = "0.8.0"
+```
+
+You can then import the crate in your code as follows:
+
+```rust
+use near_lake_primitives;
+```
+
+## Examples
+
+TBD - Please provide examples here.

--- a/lake-primitives/src/lib.rs
+++ b/lake-primitives/src/lib.rs
@@ -5,6 +5,3 @@ pub use near_indexer_primitives::{
 pub use types::{actions, block, events, receipts, state_changes, transactions};
 
 mod types;
-
-#[derive(Debug)]
-pub struct LakeContext {}


### PR DESCRIPTION
During the implementation of the #71 proposal I've realized that while it is still possible to proceed with the middleware concept, in the end, we will have pretty complex middleware for developers to write.

Thus, I've decided to give up on middlewares in favor of Contexts. In this PR I'm introducing the first-ever shareable context written for the Lake Framework RS

### ParentTransactionCache context

```rust
fn main () {
  let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
      .build()
      .expect("Failed to build the ParentTransactionCache context");
  
  LakeBuilder::default()
      .mainnet()
      .start_block_height(80504433)
      .build()
      .expect("Failed to build the Lake Framework")
      .run_with_context(handle_block, &parent_transaction_cache_ctx)
      .expect("Failed to run the Lake Framework");
}

async fn handle_block(
    mut block: Block,
    ctx: &ParentTransactionCache,
) -> anyhow::Result<()> {
    for action in block.actions() {
        println!(
            "Action receipt ID: {:?} | Parent TX hash: {:?}",
            action.receipt_id(),
            ctx.get_parent_transaction_hash(&action.receipt_id())
        );
    }
    Ok(())
}
```

You can find a source code and a README in the `lake-parent-transaction-cache` folder. I plan to publish that context along with a 0.8.0 version of the Lake Framework.

### Update (May 18, '23)

So trying to reduce some frictions I've ended up having a derive macro `LakeContext` to be able to combine contexts.

Since now we have a trait `LakeContext` (exported as `LakeContextExt`).

```rust
pub trait LakeContext {
    fn execute_before_run(&self, block: &mut near_lake_primitives::block::Block);
    fn execute_after_run(&self);
}
```

It basically requires defining two methods to run before the user-provided indexer function and after accordingly.

In the case of `ParentTransactionCache` I've put all the cache-updating logic into an `execute_before_run` method and made `execute_after_run` empty (we don't need to do anything)

Imagining a situation when a developer wants to use `ParentTransactionCache` along with some additional data they would define a context like this:

```rust
#[derive(LakeContext)]
struct MyContext {
  db_connection_string: String,
  parent_tx_cache: ParentTransactionCache,
}

// then instantiation example

let my_context = MyContext {
  db_connection_string: String::from("postgres://user:pass@host/db"),
  parent_tx_cache: ParentTransactionCache::default().build().unwrap(),
};

// User indexer function signature will be simple
async fn handle_block(
    mut block: Block,
    ctx: &MyContext,
) -> anyhow::Result<()> {
  // body
}
```

`LakeContext` derive will use every field in the structure that impls `LakeContextExt` and will add its trait methods to the top-level calls.
For **before_run** it will be in ascending order, and for the **after** descending one.

I believe this derive makes context development and usage much easier and I hope the community will start sharing their wonderful context implementation. Can't wait to see them! 