### PR TITLE
chore: 0.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.1...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.2...HEAD)
+
+## [0.7.2](https://github.com/near/near-lake-framework/compare/v0.7.2...0.7.0)
+
+- Upgrade near primitives crate to `0.17.0`
 
 ## [0.7.1](https://github.com/near/near-lake-framework/compare/v0.7.1...0.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.2](https://github.com/near/near-lake-framework/compare/v0.7.2...0.7.0)
 
 - Upgrade near primitives crate to `0.17.0`
+- Upgrade `tokio` version to the latest (`1.28.2`)
 
 ## [0.7.1](https://github.com/near/near-lake-framework/compare/v0.7.1...0.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.2...HEAD)
 
-## [0.7.2](https://github.com/near/near-lake-framework/compare/v0.7.2...0.7.0)
+## [0.7.2](https://github.com/near/near-lake-framework/compare/v0.7.1...0.7.2)
 
 - Upgrade near primitives crate to `0.17.0`
 - Upgrade `tokio` version to the latest (`1.28.2`)
 
-## [0.7.1](https://github.com/near/near-lake-framework/compare/v0.7.1...0.7.0)
+## [0.7.1](https://github.com/near/near-lake-framework/compare/v0.7.0...0.7.1)
 
 - Refactor `s3_fetchers` to allow testing
 - Fix `betanet` default region (the corresponding bucket is in different region)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.75"
 thiserror = "1.0.38"
-tokio = { version = "1.1", features = ["sync", "time"] }
+tokio = { version = "1.28.2", features = ["sync", "time", "rt", "macros"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.58.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.1"
+version = "0.7.2"
 
 [dependencies]
 anyhow = "1.0.51"
@@ -31,7 +31,7 @@ tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
-near-indexer-primitives = ">=0.16.0,<0.17.0"
+near-indexer-primitives = "0.17"
 
 [dev-dependencies]
 aws-smithy-http = "0.53.0"


### PR DESCRIPTION
- Update near primitives crates to version `0.17.0`
- Update `tokio` version to the latest (`1.28.2`)
- Bump version of the Lake Framework to `0.7.2`