### PR TITLE
chore: Upgrade near primitives to 0.17.0 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ description = "Library to connect to the NEAR Lake S3 and stream the data"
 categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "near-lake", "near-indexer"]
 authors = ["Near Inc <hello@nearprotocol.com>"]
-rust-version = "1.65.0"
+rust-version = "1.69.0"

--- a/lake-primitives/Cargo.toml
+++ b/lake-primitives/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.51"
-near-crypto = "0.16.1"
-near-primitives-core = "0.16.1"
-near-primitives = "0.16.1"
-near-indexer-primitives = ">=0.16.0,<0.17.0"
+near-crypto = "0.17.0"
+near-primitives-core = "0.17.0"
+near-primitives = "0.17.0"
+near-indexer-primitives = "0.17.0"
 paste = "1.0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.75"

--- a/lake-primitives/src/types/delegate_actions.rs
+++ b/lake-primitives/src/types/delegate_actions.rs
@@ -239,7 +239,7 @@ impl DelegateAction {
                     deposit,
                 } => Self::DelegateFunctionCall(DelegateFunctionCall {
                     method_name,
-                    args,
+                    args: args.into(),
                     gas,
                     deposit,
                 }),

--- a/lake-primitives/src/types/impl_actions.rs
+++ b/lake-primitives/src/types/impl_actions.rs
@@ -45,7 +45,7 @@ impl Action {
                     } => Self::FunctionCall(crate::actions::FunctionCall {
                         metadata: metadata.clone(),
                         method_name: method_name.clone(),
-                        args: args.clone(),
+                        args: args.clone().into(),
                         gas: *gas,
                         deposit: *deposit,
                     }),


### PR DESCRIPTION
Update the near primitives' crates to the 0.17.0 version (latest `nearcore` release `1.34.0`)

Note, the 0.17.0 version of the primitives introduced a wrapper(s) around some `Vec<u8>` for readability. However, I don't have an opinion on whether we should follow that in our simplified structures, thus I convert them into `Vec<u8>`. This might change on the release.