### PR TITLE
chore: Rename crates adding `near-` prefix to follow the naming. Fix doc-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
     - name: Run check
       run: cargo check
 
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run check
+      run: cargo test
+
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-20.04
@@ -60,7 +69,7 @@ jobs:
   release-plz:
     name: release-plz
     runs-on: ubuntu-latest
-    needs: [check, rustclippy, rustfmt]
+    needs: [check, rustclippy, rustfmt, test]
     if: ${{ github.event_name != 'pull_request' }}  # Specify the branch condition
     steps:
       - name: Checkout repository

--- a/lake-context-derive/Cargo.toml
+++ b/lake-context-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lake-context-derive"
+name = "near-lake-context-derive"
 description = "Derive macro for LakeContext"
 edition = "2021"
 version.workspace = true
@@ -12,3 +12,6 @@ proc-macro = true
 [dependencies]
 syn = "2.0"
 quote = "1.0"
+
+[dev-dependencies]
+near-lake-parent-transaction-cache = { path = "../lake-parent-transaction-cache", version = "0.8.0-beta.1" }

--- a/lake-context-derive/README.md
+++ b/lake-context-derive/README.md
@@ -1,4 +1,4 @@
-# Lake Context Derive
+# NEAR Lake Context Derive
 
 Lake Context Derive is a Rust crate that provides a derive macro for easy and convenient implementation of the `near_lake_framework::LakeContextExt` trait. This trait has two functions: `execute_before_run` and `execute_after_run` that are executed before and after the user-provided indexer function respectively.
 
@@ -6,8 +6,8 @@ Lake Context Derive is a Rust crate that provides a derive macro for easy and co
 
 The Lake Context Derive macro can be utilized by annotating the context struct with `#[derive(LakeContext)]`. This trait implementation will then facilitate the combination of different contexts. For instance, to use a `ParentTransactionCache` with some additional data, one would define a context like:
 
-```no_run
-use lake_parent_transaction_cache::ParentTransactionCache;
+```ignore
+use near_lake_parent_transaction_cache::ParentTransactionCache;
 
 #[derive(LakeContext)]
 struct MyContext {
@@ -20,10 +20,12 @@ struct MyContext {
 
 You can create an instance of your context as follows:
 
-```no_run
+```ignore
+use near_lake_parent_transaction_cache::{ParentTransactionCacheBuilder};
+
 let my_context = MyContext {
   db_connection_string: String::from("postgres://user:pass@host/db"),
-  parent_tx_cache: ParentTransactionCache::default().build().unwrap(),
+  parent_tx_cache: ParentTransactionCacheBuilder::default().build().unwrap(),
 };
 ```
 
@@ -31,7 +33,7 @@ let my_context = MyContext {
 
 This will simplify your indexer function signature. It now needs only the context as an additional parameter:
 
-```no_run
+```ignore
 async fn handle_block(
     mut block: Block,
     ctx: &MyContext,

--- a/lake-framework/Cargo.toml
+++ b/lake-framework/Cargo.toml
@@ -23,7 +23,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 
 near-lake-primitives = { path = "../lake-primitives", version = "0.8.0-beta.1" }
-lake-context-derive = { path = "../lake-context-derive", version = "0.8.0-beta.1" }
+near-lake-context-derive = { path = "../lake-context-derive", version = "0.8.0-beta.1" }
 
 [dev-dependencies]
 aws-smithy-http = "0.53.0"
@@ -38,4 +38,4 @@ once_cell = "1.8.0"
 diesel = { version = "2", features = ["postgres_backend", "postgres"] }
 
 # used by with_context_parent_tx_cache example
-lake-parent-transaction-cache = { path = "../lake-parent-transaction-cache" }
+near-lake-parent-transaction-cache = { path = "../lake-parent-transaction-cache" }

--- a/lake-framework/README.md
+++ b/lake-framework/README.md
@@ -74,7 +74,7 @@ It is an old problem that the NEAR Protocol doesn't provide the parent transacti
 ```no_run
 use near_lake_framework::near_lake_primitives;
 use near_lake_primitives::CryptoHash;
-use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
+use near_lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
 use near_lake_primitives::actions::ActionMetaDataExt;
 
 fn main() -> anyhow::Result<()> {

--- a/lake-framework/examples/with_context_parent_tx_cache.rs
+++ b/lake-framework/examples/with_context_parent_tx_cache.rs
@@ -6,7 +6,7 @@
 use near_lake_framework::near_lake_primitives;
 use near_lake_primitives::CryptoHash;
 // We need to import this trait to use the `as_function_call` method.
-use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
+use near_lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
 use near_lake_primitives::actions::ActionMetaDataExt;
 
 const CONTRACT_ID: &str = "social.near";

--- a/lake-framework/src/lib.rs
+++ b/lake-framework/src/lib.rs
@@ -4,8 +4,11 @@ extern crate derive_builder;
 
 use futures::{Future, StreamExt};
 
-pub use lake_context_derive::LakeContext;
-pub use near_lake_primitives::{self, near_indexer_primitives};
+pub use near_lake_context_derive::LakeContext;
+pub use near_lake_primitives::{
+    self,
+    near_indexer_primitives::{self, near_primitives},
+};
 
 pub use aws_credential_types::Credentials;
 pub use types::{Lake, LakeBuilder, LakeContextExt, LakeError};

--- a/lake-framework/src/types.rs
+++ b/lake-framework/src/types.rs
@@ -277,7 +277,7 @@ pub enum LakeError {
 ///
 /// ```no_run
 /// use near_lake_framework::LakeContext; // This is a derive macro
-/// use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder}; // This is a ready-to-use Context from the community that impls LakeContext trait
+/// use near_lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder}; // This is a ready-to-use Context from the community that impls LakeContext trait
 /// use near_lake_framework::LakeBuilder;
 /// # use diesel::Connection;
 ///

--- a/lake-parent-transaction-cache/Cargo.toml
+++ b/lake-parent-transaction-cache/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lake-parent-transaction-cache"
+name = "near-lake-parent-transaction-cache"
 description = "Ready-to-use context for the Lake Framework in Rust. It provides a cache for keeping the relation between transactions and receipts in cache."
 edition = "2021"
 version.workspace = true

--- a/lake-parent-transaction-cache/README.md
+++ b/lake-parent-transaction-cache/README.md
@@ -1,11 +1,11 @@
-# Lake Parent Transaction Cache (Context)
+# NEAR Lake Parent Transaction Cache (Context)
 
 Lake Parent Transaction Cache is a ready-to-use context for the Lake Framework in Rust. It provides a cache for keeping the relation between transactions and receipts in cache.
 
 ## Example Usage
 
 ```no_run
-use lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
+use near_lake_parent_transaction_cache::{ParentTransactionCache, ParentTransactionCacheBuilder};
 # use near_lake_framework::LakeBuilder;
 # use near_lake_framework::near_lake_primitives::{block::Block, actions::ActionMetaDataExt};
 
@@ -46,20 +46,20 @@ To use the Lake Parent Transaction Cache context in your Rust project, follow th
 
 ```toml
 [dependencies]
-lake_parent_transaction_cache = "<version>"
+near-lake-parent-transaction-cache = "<version>"
 ```
 
 2. Import the necessary modules in your code:
 
 ```ignore
-use lake_parent_transaction_cache::ParentTransactionCache;
+use near_lake_parent_transaction_cache::ParentTransactionCache;
 use near_lake_primitives::actions::ActionMetaDataExt;
 ```
 
 3. Create an instance of the `ParentTransactionCache` context:
 
 ```no_run
-# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+# use near_lake_parent_transaction_cache::ParentTransactionCacheBuilder;
 let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default();
 ```
 
@@ -82,7 +82,7 @@ Replace `<desired_block_height>` with the starting block height you want to use.
 We use [SizedCache](https://docs.rs/cached/0.43.0/cached/stores/struct.SizedCache.html) under the hood. So we can configure the cache size by using the `cache_size` method:
 
 ```no_run
-# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+# use near_lake_parent_transaction_cache::ParentTransactionCacheBuilder;
 let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
     .cache_size(100_000);
 ```
@@ -96,12 +96,12 @@ By default `ParentTransactionCache` context will cache the relation between Tran
 #### You can pass a Vec of AccountId
 
 ```no_run
-# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+# use near_lake_parent_transaction_cache::ParentTransactionCacheBuilder;
 use near_lake_framework::near_primitives::types::AccountId;
 
 let accounts_to_watch: Vec<AccountId> = vec![
-    String::from("alice.near).try_into().unwrap(),
-    String::from("bob.near).try_into().unwrap(),
+    String::from("alice.near").try_into().unwrap(),
+    String::from("bob.near").try_into().unwrap(),
 ];
 let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
     .for_accounts(accounts_to_watch);
@@ -110,11 +110,11 @@ let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
 #### You can pass accounts to watch one by one using `for_account` method
 
 ```no_run
-# use lake_parent_transaction_cache::ParentTransactionCacheBuilder;
+# use near_lake_parent_transaction_cache::ParentTransactionCacheBuilder;
 use near_lake_framework::near_primitives::types::AccountId;
 
 let parent_transaction_cache_ctx = ParentTransactionCacheBuilder::default()
-    .for_account(String::from("alice.near).try_into().unwrap())
-    .for_account(String::from("bob.near).try_into().unwrap());
+    .for_account(String::from("alice.near").try_into().unwrap())
+    .for_account(String::from("bob.near").try_into().unwrap());
 ```
 


### PR DESCRIPTION
In this PR I am fixing the naming of the crates by adding the missing `near-` prefix to follow the "naming convention" we have.

Along with fixing the doc-strings and examples by updating imports, I've caught a few bugs here and there and fixed them.

Since we have a test or a few and all the docs are expected to pass the tests I've added back the `test` action to the CI.