### PR TITLE
chore: 0.7.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.2...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.3...HEAD)
+
+## [0.7.3](https://github.com/near/near-lake-framework/compare/v0.7.2...0.7.3)
+
+* Expose `s3_fetchers` module to allow using the underlying functionality in other projects
+* Minor refactoring of `s3_fetchers` module
 
 ## [0.7.2](https://github.com/near/near-lake-framework/compare/v0.7.1...0.7.2)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake-framework"
-version = "0.0.0" # managed by cargo-workspaces, see below
+version = "0.0.0"                                                          # managed by cargo-workspaces, see below
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-lake-framework"
 description = "Library to connect to the NEAR Lake S3 and stream the data"
@@ -12,7 +12,7 @@ rust-version = "1.58.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.2"
+version = "0.7.3"
 
 [dependencies]
 anyhow = "1.0.51"


### PR DESCRIPTION
Releasing to include changes:

* Expose `s3_fetchers` module to allow using the underlying functionality in other projects
* Minor refactoring of `s3_fetchers` module