### PR TITLE
chore: Upgrade AWS SDK dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.2...HEAD)
 - Simpler start boilerplate, simpler structures to deal with!
+- Upgrade to latest AWS SDK version (*since beta.3*)
 
 ### Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 # cargo-workspaces
 [workspace.package]
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-lake-framework-rs"
 description = "Library to connect to the NEAR Lake S3 and stream the data"

--- a/lake-framework/Cargo.toml
+++ b/lake-framework/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-aws-config = "0.53.0"
-aws-types = "0.53.0"
-aws-credential-types = "0.53.0"
-aws-sdk-s3 = "0.23.0"
+aws-config = { version = "1.0.0", features = ["behavior-version-latest"] }
+aws-types = "1.0.0"
+aws-credential-types = "1.0.0"
+aws-sdk-s3 = "0.39.0"
 async-stream = "0.3.3"
 async-trait = "0.1.64"
 derive_builder = "0.11.2"
@@ -26,7 +26,8 @@ near-lake-primitives = { path = "../lake-primitives", version = "0.8.0-beta.2" }
 near-lake-context-derive = { path = "../lake-context-derive", version = "0.8.0-beta.2" }
 
 [dev-dependencies]
-aws-smithy-http = "0.53.0"
+aws-smithy-http = "0.60.0"
+aws-smithy-types = "1.0.0"
 # use by examples
 anyhow = "1.0.51"
 

--- a/lake-framework/README.md
+++ b/lake-framework/README.md
@@ -226,19 +226,21 @@ $ mkdir -p /data/near-lake-custom && minio server /data
 use near_lake_framework::LakeBuilder;
 
 # #[tokio::main]
-# async fn main() {
-let aws_config = aws_config::from_env().load().await;
-let mut s3_conf = aws_sdk_s3::config::Builder::from(&aws_config)
-    .endpoint_url("http://0.0.0.0:9000")
-    .build();
+# async fn main() -> anyhow::Result<()> {
+    let aws_config = aws_config::from_env().load().await;
+    let s3_config = aws_sdk_s3::config::Builder::from(&aws_types::SdkConfig::from(aws_config))
+        .endpoint_url("http://0.0.0.0:9000")
+        .build();
 
-let lake = LakeBuilder::default()
-    .s3_config(s3_conf)
-    .s3_bucket_name("near-lake-data-custom")
-    .s3_region_name("eu-central-1")
-    .start_block_height(1)
-    .build()
-    .expect("Failed to build LakeConfig");
+    LakeBuilder::default()
+        .s3_bucket_name("near-lake-custom")
+        .s3_region_name("eu-central-1")
+        .start_block_height(0)
+        .s3_config(s3_config)
+        .build()
+        .expect("Failed to build Lake");
+
+#    Ok(())
 # }
 ```
 

--- a/lake-framework/src/types.rs
+++ b/lake-framework/src/types.rs
@@ -128,28 +128,28 @@ pub enum LakeError {
         #[from]
         error_message: serde_json::Error,
     },
-    #[error("AWS S3 error")]
+    #[error("AWS S3 error: {error}")]
     AwsGetObjectError {
         #[from]
         error: aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
     },
-    #[error("AWS S3 error")]
+    #[error("AWS S3 error: {error}")]
     AwsLisObjectsV2Error {
         #[from]
         error:
             aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error>,
     },
-    #[error("Failed to convert integer")]
+    #[error("Failed to convert integer: {error}")]
     IntConversionError {
         #[from]
         error: std::num::TryFromIntError,
     },
-    #[error("Join error")]
+    #[error("Join error: {error}")]
     JoinError {
         #[from]
         error: tokio::task::JoinError,
     },
-    #[error("Failed to start runtime")]
+    #[error("Failed to start runtime: {error}")]
     RuntimeStartError {
         #[from]
         error: std::io::Error,

--- a/lake-framework/src/types.rs
+++ b/lake-framework/src/types.rs
@@ -131,12 +131,13 @@ pub enum LakeError {
     #[error("AWS S3 error")]
     AwsGetObjectError {
         #[from]
-        error: aws_sdk_s3::types::SdkError<aws_sdk_s3::error::GetObjectError>,
+        error: aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
     },
     #[error("AWS S3 error")]
     AwsLisObjectsV2Error {
         #[from]
-        error: aws_sdk_s3::types::SdkError<aws_sdk_s3::error::ListObjectsV2Error>,
+        error:
+            aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error>,
     },
     #[error("Failed to convert integer")]
     IntConversionError {


### PR DESCRIPTION
This PR introduced **beta.3** for 0.8.0 version

- [x] Upgrade AWS SDK dependencies to the latest (resolves #90)
- [x] Improve AWS SDK error propagation to simplify debugging