### PR TITLE
chore: Upgrade `aws` crates to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.3...HEAD)
 
+* Upgrade all `aws` crates to the latest version
+* Undeylying AWS error will now be printed
+
 ## [0.7.3](https://github.com/near/near-lake-framework/compare/v0.7.2...0.7.3)
 
 * Expose `s3_fetchers` module to allow using the underlying functionality in other projects

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ version = "0.7.3"
 
 [dependencies]
 anyhow = "1.0.51"
-aws-config = "0.53.0"
-aws-types = "0.53.0"
-aws-credential-types = "0.53.0"
-aws-sdk-s3 = "0.23.0"
+aws-config = { version = "1.0.0", features = ["behavior-version-latest"] }
+aws-types = "1.0.0"
+aws-credential-types = "1.0.0"
+aws-sdk-s3 = "0.39.1"
 async-stream = "0.3.3"
 async-trait = "0.1.64"
 derive_builder = "0.11.2"
@@ -34,7 +34,8 @@ tracing = "0.1.13"
 near-indexer-primitives = "0.17"
 
 [dev-dependencies]
-aws-smithy-http = "0.53.0"
+aws-smithy-http = "0.60.0"
+aws-smithy-types = "1.0.1"
 
 [lib]
 doctest = false

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,7 +120,7 @@ pub enum LakeError<E> {
         #[from]
         error_message: serde_json::Error,
     },
-    #[error("AWS S3 error")]
+    #[error("AWS S3 error: {error}")]
     AwsError {
         #[from]
         error: aws_sdk_s3::error::SdkError<E>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,7 +123,7 @@ pub enum LakeError<E> {
     #[error("AWS S3 error")]
     AwsError {
         #[from]
-        error: aws_sdk_s3::types::SdkError<E>,
+        error: aws_sdk_s3::error::SdkError<E>,
     },
     #[error("Failed to convert integer")]
     IntConversionError {


### PR DESCRIPTION
We're still on `0.7.x` and not quite ready to upgrade to `0.8.x`. This PR upgrades the `aws-*` crates on the `0.7.x` branch to the latest version, as there is some newer functionality that we require.