### PR TITLE
refactor(0.7.x): 0.7.5 with exposed non-retryable s3_fetchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.4...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.5...HEAD)
 
-## [0.7.3](https://github.com/near/near-lake-framework/compare/v0.7.2...0.7.4)
+## [0.7.5](https://github.com/near/near-lake-framework/compare/v0.7.3...0.7.5)
+
+* Refactor `s3_fetchers` module to allow exposing the underlying functionality:
+  * `s3_fetchers::fetch_block` (without retrying)
+  * `s3_fetchers::fetch_shard` (without retrying)
+
+## [0.7.4](https://github.com/near/near-lake-framework/compare/v0.7.2...0.7.4)
 
 * Upgrade all `aws` crates to the latest version
 * Undeylying AWS error will now be printed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.58.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.4"
+version = "0.7.5"
 
 [dependencies]
 anyhow = "1.0.51"
@@ -20,6 +20,7 @@ aws-config = { version = "1.0.0", features = ["behavior-version-latest"] }
 aws-types = "1.0.0"
 aws-credential-types = "1.0.0"
 aws-sdk-s3 = "0.39.1"
+aws-smithy-types = "1.0.1"
 async-stream = "0.3.3"
 async-trait = "0.1.64"
 derive_builder = "0.11.2"
@@ -35,7 +36,6 @@ near-indexer-primitives = "0.17"
 
 [dev-dependencies]
 aws-smithy-http = "0.60.0"
-aws-smithy-types = "1.0.1"
 
 [lib]
 doctest = false

--- a/src/types.rs
+++ b/src/types.rs
@@ -115,22 +115,22 @@ impl LakeConfigBuilder {
 #[allow(clippy::enum_variant_names)]
 #[derive(thiserror::Error, Debug)]
 pub enum LakeError<E> {
-    #[error("Failed to parse structure from JSON: {error_message}")]
+    #[error("Failed to parse structure from JSON: {error_message:?}")]
     ParseError {
         #[from]
         error_message: serde_json::Error,
     },
-    #[error("AWS S3 error: {error}")]
+    #[error("AWS S3 error: {error:?}")]
     AwsError {
         #[from]
         error: aws_sdk_s3::error::SdkError<E>,
     },
-    #[error("Failed to convert integer: {error}")]
+    #[error("Failed to convert integer: {error:?}")]
     IntConversionError {
         #[from]
         error: std::num::TryFromIntError,
     },
-    #[error("AWS Smithy byte_stream error: {error}")]
+    #[error("AWS Smithy byte_stream error: {error:?}")]
     AwsSmithyError {
         #[from]
         error: aws_smithy_types::byte_stream::error::Error,

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,9 +125,14 @@ pub enum LakeError<E> {
         #[from]
         error: aws_sdk_s3::error::SdkError<E>,
     },
-    #[error("Failed to convert integer")]
+    #[error("Failed to convert integer: {error}")]
     IntConversionError {
         #[from]
         error: std::num::TryFromIntError,
+    },
+    #[error("AWS Smithy byte_stream error: {error}")]
+    AwsSmithyError {
+        #[from]
+        error: aws_smithy_types::byte_stream::error::Error,
     },
 }


### PR DESCRIPTION
This PR should address #97 and bump the version of the crate to 0.7.5

I had to extract the code from the infinity loops of `fetch_block_or_retry` and a similar function for the shards.

I made two new functions: `fetch_block` and `fetch_shard`, and made them public.

