### PR TITLE
chore: Upgraded dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,27 +15,27 @@ rust-version = "1.58.1"
 version = "0.7.5"
 
 [dependencies]
-anyhow = "1.0.51"
-aws-config = { version = "1.0.0", features = ["behavior-version-latest"] }
-aws-types = "1.0.0"
-aws-credential-types = "1.0.0"
-aws-sdk-s3 = "0.39.1"
-aws-smithy-types = "1.0.1"
-async-stream = "0.3.3"
-async-trait = "0.1.64"
-derive_builder = "0.11.2"
-futures = "0.3.23"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.75"
-thiserror = "1.0.38"
-tokio = { version = "1.28.2", features = ["sync", "time", "rt", "macros"] }
-tokio-stream = { version = "0.1" }
-tracing = "0.1.13"
+anyhow = "1.0.79"
+aws-config = { version = "1.1.3", features = ["behavior-version-latest"] }
+aws-types = "1.1.3"
+aws-credential-types = "1.1.3"
+aws-sdk-s3 = "1.13.0"
+aws-smithy-types = "1.1.3"
+async-stream = "0.3.5"
+async-trait = "0.1.77"
+derive_builder = "0.13.0"
+futures = "0.3.30"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.111"
+thiserror = "1.0.56"
+tokio = { version = "1.35.1", features = ["sync", "time", "rt", "macros"] }
+tokio-stream = { version = "0.1.14" }
+tracing = "0.1.40"
 
-near-indexer-primitives = "0.17"
+near-indexer-primitives = "0.20.0"
 
 [dev-dependencies]
-aws-smithy-http = "0.60.0"
+aws-smithy-http = "0.60.3"
 
 [lib]
 doctest = false


### PR DESCRIPTION
In this PR: 
1. Upgraded dependencies versions
2. Upgraded NEAR crates to 0.20.0 release 