### PR TITLE
chore: release v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.6...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.7...HEAD)
+
+## [0.7.7](https://github.com/near/near-lake-framework/compare/v0.7.6...0.7.7)
+
+* Refactor `s3_fetchers` module to allow use `list_block_heights` outside of the framework
 
 ## [0.7.6](https://github.com/near/near-lake-framework/compare/v0.7.5...0.7.6)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "near-lake", "near-indexer"]
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.58.1"
+rust-version = "1.75.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.6"
+version = "0.7.7"
 
 [dependencies]
 anyhow = "1.0.79"

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -76,7 +76,7 @@ impl S3Client for LakeS3Client {
 
 /// Queries the list of the objects in the bucket, grouped by "/" delimiter.
 /// Returns the list of block heights that can be fetched
-pub(crate) async fn list_block_heights(
+pub async fn list_block_heights(
     lake_s3_client: &impl S3Client,
     s3_bucket_name: &str,
     start_from_block_height: crate::types::BlockHeight,


### PR DESCRIPTION
near-lake-framework 0.7.6 -> 0.7.7

Make `list_block_heights` public
Bump version
Update CHANGELOG
