### PR TITLE
feat: Allow custom configuration of `S3Client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.7...HEAD)
 
+* Expose `s3_client::S3Client` trait so that custom S3 client implementations can be configured via `LakeConfigBuilder::s3_client`
+
+### Breaking Change
+
+* Errors returned from public `s3_fetcher` methods have changed slightly to support the newly exposed `S3Client`. As these methods serve a rare use-case this is only a minor bump.
+
 ## [0.7.7](https://github.com/near/near-lake-framework/compare/v0.7.6...0.7.7)
 
 * Refactor `s3_fetchers` module to allow use `list_block_heights` outside of the framework

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.7"
+version = "0.7.8"
 
 [dependencies]
 anyhow = "1.0.79"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,5 @@ tracing = "0.1.40"
 
 near-indexer-primitives = "0.20.0"
 
-[dev-dependencies]
-aws-smithy-http = "0.60.3"
-
 [lib]
 doctest = false

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -1,0 +1,82 @@
+use std::error::Error;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+pub type S3ClientError = Arc<dyn Error + Send + Sync + 'static>;
+
+#[derive(Debug, thiserror::Error)]
+pub struct GetObjectBytesError(pub S3ClientError);
+
+impl std::ops::Deref for GetObjectBytesError {
+    type Target = S3ClientError;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for GetObjectBytesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GetObjectBytesError: {}", self.0)
+    }
+}
+
+impl From<aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>>
+    for GetObjectBytesError
+{
+    fn from(
+        error: aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+    ) -> Self {
+        Self(Arc::new(error))
+    }
+}
+
+impl From<aws_smithy_types::byte_stream::error::Error> for GetObjectBytesError {
+    fn from(error: aws_smithy_types::byte_stream::error::Error) -> Self {
+        Self(Arc::new(error))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub struct ListCommonPrefixesError(pub S3ClientError);
+
+impl std::fmt::Display for ListCommonPrefixesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ListCommonPrefixesError: {}", self.0)
+    }
+}
+
+impl std::ops::Deref for ListCommonPrefixesError {
+    type Target = S3ClientError;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error>>
+    for ListCommonPrefixesError
+{
+    fn from(
+        error: aws_sdk_s3::error::SdkError<
+            aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error,
+        >,
+    ) -> Self {
+        Self(Arc::new(error))
+    }
+}
+
+#[async_trait]
+pub trait S3Client: Send + Sync {
+    async fn get_object_bytes(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Result<Vec<u8>, GetObjectBytesError>;
+
+    async fn list_common_prefixes(
+        &self,
+        bucket: &str,
+        start_after_prefix: &str,
+    ) -> Result<Vec<String>, ListCommonPrefixesError>;
+}

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 pub type S3ClientError = Arc<dyn Error + Send + Sync + 'static>;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub struct GetObjectBytesError(pub S3ClientError);
 
 impl std::ops::Deref for GetObjectBytesError {
@@ -38,7 +38,7 @@ impl From<aws_smithy_types::byte_stream::error::Error> for GetObjectBytesError {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub struct ListCommonPrefixesError(pub S3ClientError);
 
 impl std::fmt::Display for ListCommonPrefixesError {

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -155,7 +155,7 @@ pub async fn fetch_block_or_retry(
                     {
                         tracing::debug!(
                             target: crate::LAKE_FRAMEWORK,
-                            "Block #{:0>12} not found. Retrying in immediately...\n{:#?}",
+                            "Block #{:0>12} not found. Retrying immediately...\n{:#?}",
                             block_height,
                             get_object_error,
                         );

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -13,9 +13,7 @@ impl LakeS3Client {
     pub fn new(s3: aws_sdk_s3::Client) -> Self {
         Self { s3 }
     }
-}
 
-impl LakeS3Client {
     pub fn from_conf(config: aws_sdk_s3::config::Config) -> Self {
         let s3_client = aws_sdk_s3::Client::from_conf(config);
 

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -220,7 +220,7 @@ pub async fn fetch_shard_or_retry(
                     {
                         tracing::debug!(
                             target: crate::LAKE_FRAMEWORK,
-                            "Shard {} of block #{:0>12} not found. Retrying in immediately...\n{:#?}",
+                            "Shard {} of block #{:0>12} not found. Retrying immediately...\n{:#?}",
                             shard_id,
                             block_height,
                             list_objects_error,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use crate::s3_client::{GetObjectBytesError, ListCommonPrefixesError, S3Client};
+
 /// Type alias represents the block height
 pub type BlockHeight = u64;
 
@@ -137,25 +139,25 @@ impl LakeConfigBuilder {
 
 #[allow(clippy::enum_variant_names)]
 #[derive(thiserror::Error, Debug)]
-pub enum LakeError<E> {
+pub enum LakeError {
     #[error("Failed to parse structure from JSON: {error_message:?}")]
     ParseError {
         #[from]
         error_message: serde_json::Error,
     },
-    #[error("AWS S3 error: {error:?}")]
-    AwsError {
+    #[error("Get object error: {error:?}")]
+    S3GetError {
         #[from]
-        error: aws_sdk_s3::error::SdkError<E>,
+        error: GetObjectBytesError,
+    },
+    #[error("List objects error: {error:?}")]
+    S3ListError {
+        #[from]
+        error: ListCommonPrefixesError,
     },
     #[error("Failed to convert integer: {error:?}")]
     IntConversionError {
         #[from]
         error: std::num::TryFromIntError,
-    },
-    #[error("AWS Smithy byte_stream error: {error:?}")]
-    AwsSmithyError {
-        #[from]
-        error: aws_smithy_types::byte_stream::error::Error,
     },
 }


### PR DESCRIPTION
Previously, the `S3Client` trait is used to mock requests made to S3 so that we can unit test our S3 related logic. This PR allows custom implementations of this trait to be configured and used within Lake Framework. This grants users greater control over the S3 requests made, which would otherwise not be possible via configuration of `s3_config` alone. The main motive for this change is to add caching of requests, but the solution is generic enough that it could be extended to many different use cases.

## `S3Client` trait updates

`S3Client` has been updated to make it easier to work with from external crates. Previously, it was a thin wrapper over `GetObject` and `ListObjects`, but it has been abstracted further so the user does not have to deal with the complex return types of these operations.

On success, the `S3Client` methods now return primitive types, as opposed to high level request wrappers such as `GetObjectOutput`. This makes both caching and mocking much easier.

### Type Erasure
On failure, we return `dyn std::error::Error`. This allows any error to be returned, rather than the complex `SdkError<GetObjectError>`. Without this, every error returned from the method would be re-constructed as an S3 error, which doesn't make sense if the error it self is related to, for example, `Mutex` locking.

This comes with the downside of errors being "opaque", so responding to specific errors is more difficult. If concrete error types are needed, this opaque error will need to be `downcast`, as you'll see in `s3_fetchers.rs`.

Each method returns a "newtype" wrapper around `dyn std::error::Error` to provide some separation between the two methods, and make them a _little_ easier to work with.

### `Arc<Error>` instead of `Box<Error>`
While `Box` is cheaper and easier to work with, it isn't thread safe. This makes it harder to work with in an async context. Therefore, I've opted to use `Arc` instead, even though it comes with a slight runtime penalty.


## Dynamic Dispatch

Previously, the code used static dispatch (`impl S3Client`) to determine `S3Client`, meaning the underlying type was known at compile time. `impl` is really just short-hand for generics, so making `S3Client` configurable meant that this generic needed to be propagated through all public facing methods - essentially creating a breaking change.

To mitigate the above, I have replaced the implementation to use dynamic dispatch `dyn S3Client`. This removes the need for generics, meaning this change can be released without a major version bump.

Dynamic dispatch comes with a runtime penalty as the concrete type is determined at runtime. But as most s3 requests are made ahead of time (prefetch), this additional overhead should be negligible.

