### PR TITLE
chore: Release 0.7.9 with support of nearcore 1.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.7...HEAD)
+## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.9...HEAD)
 
+## [0.7.9](https://github.com/near/near-lake-framework/compare/v0.7.7...0.7.9)
+
+* Upgrade `near-indexer-primitives` to `0.23.0` (nearcore-1.40.0)
 * Expose `s3_client::S3Client` trait so that custom S3 client implementations can be configured via `LakeConfigBuilder::s3_client`
 
 ### Breaking Change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.8"
+version = "0.7.9"
 
 [dependencies]
 anyhow = "1.0.79"
@@ -32,7 +32,7 @@ tokio = { version = "1.35.1", features = ["sync", "time", "rt", "macros"] }
 tokio-stream = { version = "0.1.14" }
 tracing = "0.1.40"
 
-near-indexer-primitives = "0.20.0"
+near-indexer-primitives = "0.23.0"
 
 [lib]
 doctest = false


### PR DESCRIPTION
* Upgrade `near-indexer-primitives` to `0.23.0` (nearcore-1.40.0)
* Expose `s3_client::S3Client` trait so that custom S3 client implementations can be configured via `LakeConfigBuilder::s3_client`

### Breaking Change

* Errors returned from public `s3_fetcher` methods have changed slightly to support the newly exposed `S3Client`. As these methods serve a rare use-case this is only a minor bump.