### PR TITLE
add fastnear authorization_token supports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.7.10...HEAD)
 
+## [0.7.11](https://github.com/near/near-lake-framework/compare/v0.7.10...0.7.11)
+
+* Upgrade `near-indexer-primitives` to `0.28.0` (nearcore-2.4.0)
+* Updated `FastNearClient` to include `authorization_token` in the headers
+
+
 ## [0.7.10](https://github.com/near/near-lake-framework/compare/v0.7.9...0.7.10)
 
 * Upgrade `near-indexer-primitives` to `0.27.0` (nearcore-2.3.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ aws-sdk-s3 = "1.13.0"
 aws-smithy-types = "1.1.3"
 async-stream = "0.3.5"
 async-trait = "0.1.77"
-derive_builder = "0.13.0"
+derive_builder = "0.20.2"
 futures = "0.3.30"
 reqwest = { version = "0.12.7", features = ["json"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
-thiserror = "1.0.56"
+thiserror = "2.0.11"
 tokio = { version = "1.35.1", features = ["sync", "time", "rt", "macros"] }
 tokio-stream = { version = "0.1.14" }
 tracing = "0.1.40"
 
-near-indexer-primitives = "0.27.0"
+near-indexer-primitives = "0.28.0"
 
 [lib]
 doctest = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ pub fn streamer<T: Into<providers::NearLakeFrameworkConfig>>(
     let (sender, receiver) = tokio::sync::mpsc::channel(config.blocks_preload_pool_size());
     match config {
         providers::NearLakeFrameworkConfig::Lake(config) => {
-            (tokio::spawn(s3::start(sender, config)), receiver)
+            (tokio::spawn(s3::start(sender, *config)), receiver)
         }
         providers::NearLakeFrameworkConfig::FastNear(config) => {
             (tokio::spawn(fastnear::start(sender, config)), receiver)

--- a/src/providers/fastnear/types.rs
+++ b/src/providers/fastnear/types.rs
@@ -11,6 +11,7 @@ pub type BlockHeight = u64;
 ///    let config = FastNearConfigBuilder::default()
 ///        .testnet()
 ///        .start_block_height(82422587)
+///        .authorization_token(Some("your_token_here".to_string()))
 ///        .build()
 ///        .expect("Failed to build FastNearConfig");
 /// # }
@@ -21,6 +22,9 @@ pub struct FastNearConfig {
     /// Fastnear data endpoint
     #[builder(setter(into))]
     pub(crate) endpoint: String,
+    /// Optional authorization token for accessing the FastNear Data
+    #[builder(default)]
+    pub authorization_token: Option<String>,
     /// Defines the block height to start indexing from
     pub(crate) start_block_height: u64,
     /// Number of threads to use for fetching data
@@ -40,6 +44,7 @@ impl FastNearConfigBuilder {
     ///    let config = FastNearConfigBuilder::default()
     ///        .mainnet()
     ///        .start_block_height(65231161)
+    ///        .authorization_token(Some("your_token_here".to_string()))
     ///        .build()
     ///        .expect("Failed to build FastNearConfig");
     /// # }
@@ -57,6 +62,7 @@ impl FastNearConfigBuilder {
     ///    let config = FastNearConfigBuilder::default()
     ///        .testnet()
     ///        .start_block_height(82422587)
+    ///        .authorization_token(Some("your_token_here".to_string()))
     ///        .build()
     ///        .expect("Failed to build FastNearConfig");
     /// # }
@@ -76,6 +82,7 @@ impl FastNearConfigBuilder {
 ///        .mainnet()
 ///        .num_threads(8)
 ///        .start_block_height(82422587)
+///        .authorization_token(Some("your_token_here".to_string()))
 ///        .build()
 ///        .expect("Failed to build FastNearConfig");
 /// # }
@@ -98,6 +105,10 @@ pub enum FastNearError {
     BlockDoesNotExist(String),
     #[error("Request error: {0}")]
     RequestError(reqwest::Error),
+    #[error("Unauthorized request: {0}")]
+    Unauthorized(String),
+    #[error("Forbidden request: {0}")]
+    Forbidden(String),
     #[error("An unknown error occurred: {0}")]
     UnknownError(String),
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,7 +2,7 @@ pub mod fastnear;
 pub mod s3;
 
 pub enum NearLakeFrameworkConfig {
-    Lake(s3::types::LakeConfig),
+    Lake(Box<s3::types::LakeConfig>),
     FastNear(fastnear::types::FastNearConfig),
 }
 
@@ -17,7 +17,7 @@ impl NearLakeFrameworkConfig {
 
 impl From<s3::types::LakeConfig> for NearLakeFrameworkConfig {
     fn from(config: s3::types::LakeConfig) -> Self {
-        NearLakeFrameworkConfig::Lake(config)
+        NearLakeFrameworkConfig::Lake(Box::new(config))
     }
 }
 


### PR DESCRIPTION
* Upgrade `near-indexer-primitives` to `0.28.0` (nearcore-2.4.0)
* Updated `FastNearClient` to include `authorization_token` in the headers