### PR TITLE
Manually handle redirects to use auth headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "2.0.11"
 tokio = { version = "1.35.1", features = ["sync", "time", "rt", "macros"] }
 tokio-stream = { version = "0.1.14" }
 tracing = "0.1.40"
+url = "2.5.4"
 
 near-indexer-primitives = "0.30.0-rc.1"
 

--- a/src/providers/fastnear/types.rs
+++ b/src/providers/fastnear/types.rs
@@ -1,6 +1,6 @@
+pub const MAX_REDIRECTS: usize = 5;
 /// Type alias represents the block height
 pub type BlockHeight = u64;
-
 /// Configuration struct for Fast NEAR Data Framework
 /// NB! Consider using [`FastNearConfigBuilder`]
 /// Building the `FastNearConfig` example:
@@ -111,6 +111,8 @@ pub enum FastNearError {
     Forbidden(String),
     #[error("An unknown error occurred: {0}")]
     UnknownError(String),
+    #[error("Redirect error: {0}")]
+    RedirectError(String),
 }
 
 impl From<reqwest::Error> for FastNearError {


### PR DESCRIPTION
This pull request introduces improvements to the `FastNearClient` implementation, focusing on handling HTTP redirects, and updates dependencies to support these changes. The most important updates include adding redirect handling logic, defining a maximum number of redirects, and introducing a new error type for redirect-related issues.

### Enhancements to HTTP redirect handling:

* [`src/providers/fastnear/client.rs`](diffhunk://#diff-84d2c09c3ffcee615160cb018676cfa76a364eff491292df0a06b67d5177b8d5L44-R67): Updated the `FastNearClient` implementation to manually handle HTTP redirects by resolving relative URLs, retrying up to a maximum number of redirects, and ensuring authentication headers are preserved. [[1]](diffhunk://#diff-84d2c09c3ffcee615160cb018676cfa76a364eff491292df0a06b67d5177b8d5L44-R67) [[2]](diffhunk://#diff-84d2c09c3ffcee615160cb018676cfa76a364eff491292df0a06b67d5177b8d5R77-R81)

* [`src/providers/fastnear/types.rs`](diffhunk://#diff-d860f29f261eb2c1efc4b3b15af2eb246d11d4a4f5b201643d9442b57b8447bbR1-L3): Added a constant `MAX_REDIRECTS` (set to 5) to limit the number of redirects the client will follow.

* [`src/providers/fastnear/types.rs`](diffhunk://#diff-d860f29f261eb2c1efc4b3b15af2eb246d11d4a4f5b201643d9442b57b8447bbR114-R115): Introduced a new error type, `RedirectError`, in the `FastNearError` enum to handle errors related to redirects.

### Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R35): Added the `url` crate (version 2.5.4) as a dependency to support URL parsing and manipulation for redirect handling.