### PR TITLE
Bumped version to 0.7.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "near-lake", "near-indexer"]
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.81.0"
+rust-version = "1.86.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.7.12"
+version = "0.7.13"
 
 [dependencies]
 anyhow = "1.0.79"
@@ -34,7 +34,7 @@ tokio-stream = { version = "0.1.14" }
 tracing = "0.1.40"
 url = "2.5.4"
 
-near-indexer-primitives = "0.30.0-rc.1"
+near-indexer-primitives = "0.31.1"
 
 [lib]
 doctest = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ pub use near_indexer_primitives;
 
 pub use aws_credential_types::Credentials;
 
-mod providers;
+pub mod providers;
 
 pub use providers::fastnear;
 pub use providers::s3;


### PR DESCRIPTION
This pull request updates dependencies and improves module visibility in the codebase. The most important changes are grouped below:

Dependency updates:

* Increased the minimum required Rust version to `1.86.0` in `Cargo.toml` for compatibility with newer language features.
* Updated the `near-indexer-primitives` dependency to version `0.31.1` in `Cargo.toml`, ensuring access to the latest features and fixes.
* Bumped the workspace metadata version to `0.7.13` in `Cargo.toml`.

Module visibility improvements:

* Changed the visibility of the `providers` module from private to public in `src/lib.rs`, making its contents accessible to external code.